### PR TITLE
Feat: 웹소켓 스코어 기록/조회 기능 개발

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,3 @@
-# Dockerfile(로컬용)
-
 # 베이스 이미지 설정
 FROM python:3.12.4-slim
 LABEL authors="minjeong"
@@ -11,7 +9,10 @@ WORKDIR /app
 RUN apt-get update && apt-get install -y \
     build-essential \
     pkg-config \
-    libmariadb-dev
+    libmariadb-dev \
+    qt5-qmake \
+    qtbase5-dev \
+    && apt-get clean
 
 # 필요 패키지 복사 및 설치
 COPY requirements.txt .
@@ -20,6 +21,9 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 # wait-for-it.sh 스크립트 복사
 COPY wait-for-it.sh /wait-for-it.sh
+
+# wait-for-it.sh 실행 권한 부여
+RUN chmod +x /wait-for-it.sh
 
 # 프로젝트 파일 복사
 COPY . .
@@ -31,4 +35,4 @@ ENV DJANGO_SETTINGS_MODULE=golbang.settings
 EXPOSE 8000
 
 # 명령어 설정
-CMD ["/wait-for-it.sh", "db:3306", "--", "sh", "-c", "python manage.py migrate && python manage.py runserver 0.0.0.0:8000"]
+CMD ["/wait-for-it.sh", "db:3306", "--", "/wait-for-it.sh", "redis:6379", "--", "sh", "-c", "python manage.py migrate && python manage.py runserver 0.0.0.0:8000"]

--- a/auth/jwt_auth_middleware.py
+++ b/auth/jwt_auth_middleware.py
@@ -1,0 +1,60 @@
+import logging
+
+from channels.exceptions import DenyConnection
+from channels.middleware import BaseMiddleware
+from channels.db import database_sync_to_async
+from django.contrib.auth.models import AnonymousUser
+from rest_framework_simplejwt.tokens import AccessToken
+from django.db import close_old_connections
+
+class JWTAuthMiddleware(BaseMiddleware):
+    async def __call__(self, scope, receive, send):
+        close_old_connections()
+
+        # 토큰 추출
+        token = self.get_token_from_scope(scope)
+
+        # 토큰으로부터 사용자 ID 추출 및 검증
+        if token:
+            user_id = await self.get_user_from_token(token)
+            logging.info(f"User ID: {user_id}")
+            if user_id:
+                scope['user'] = await self.get_user(user_id)
+                logging.info('user %s', scope['user'])
+
+            else:
+                scope['user'] = AnonymousUser()  # 유효하지 않은 토큰
+                logging.info('AnonymousUser %s', scope['user'])
+                raise DenyConnection("INVALID_TOKEN")
+
+        else:
+            scope['user'] = AnonymousUser()  # 토큰이 없을 경우
+            raise DenyConnection("NOT_FOUND_TOKEN")
+
+        return await super().__call__(scope, receive, send)
+
+    @database_sync_to_async
+    def get_user(self, user_id):
+        try:
+            from accounts.models import User
+            return User.objects.get(id=user_id)
+        except User.DoesNotExist:
+            return AnonymousUser()
+
+    @database_sync_to_async
+    def get_user_from_token(self, token):
+        try:
+            access_token = AccessToken(token)
+            return access_token['user_id']
+        except Exception:
+            raise DenyConnection("NOT_FOUND_USER_FROM_TOKEN")
+    def get_token_from_scope(self, scope):
+        headers = dict(scope.get("headers", []))
+        logging.info('headers: %s', headers)
+        auth_header = headers.get(b'authorization', b'').decode('utf-8')
+        logging.info('auth_header: %s', auth_header)
+        if auth_header.startswith('Bearer '):
+            return auth_header.split(' ')[1]
+
+        else:
+            return None

--- a/docker-compose.moon.yml
+++ b/docker-compose.moon.yml
@@ -1,0 +1,46 @@
+# docker-compose.yml(로컬용)
+services:     # 컨테이너 지정
+
+  web:
+    container_name: web
+    build: .
+    environment:
+      DJANGO_SETTINGS_MODULE: golbang.settings
+      REDIS_URL: redis://redis:6379/0  # Redis URL 환경 변수 설정
+      REDIS_HOST: redis
+    restart: always
+    volumes:
+      - .:/app
+    ports:
+      - "8000:8000"
+    env_file:
+      - .env
+
+  db:
+    container_name: db
+    image: mariadb:latest
+    restart: always
+    environment:
+      MYSQL_ROOT_PASSWORD: ${MYSQL_DB_PASSWORD}
+      MYSQL_DATABASE: ${MYSQL_DB_NAME}
+      MYSQL_USER: ${MYSQL_DB_USER}
+      MYSQL_PASSWORD: ${MYSQL_DB_PASSWORD}
+    ports:  # 포트포워딩 - 로컬의 호스트가 3306포트를 사용 중일 수 있으므로 3307 포트를 도커 컨테이너의 3306 포트로 포워딩해줌
+      - "3307:3306"
+    env_file: # 설정은 .env 파일에 의존
+      - .env
+    volumes:  # 파일 시스템 정의
+      - dbdata:/var/lib/mysql
+
+  redis:
+    container_name: redis
+    image: redis:latest
+    restart: always
+    ports: # 포트포워딩 - 로컬의 호스트가 6379 포트를 사용 중일 수 있으므로 6379 포트를 도커 컨테이너의 6379 포트로 포워딩해줌
+      - "6379:6379"
+    volumes: # 파일 시스템 정의
+      - redisdata:/data
+
+volumes:
+  dbdata:
+  redisdata:

--- a/golbang/asgi.py
+++ b/golbang/asgi.py
@@ -6,15 +6,13 @@ It exposes the ASGI callable as a module-level variable named ``application``.
 For more information on this file, see
 https://docs.djangoproject.com/en/5.0/howto/deployment/asgi/
 """
-
 import os
-from django.core.asgi import get_asgi_application
 
-# channels 라우팅과 미들웨어는 Django 초기화 이후에 가져와야 합니다.
-from channels.auth import AuthMiddlewareStack
 from channels.routing import ProtocolTypeRouter, URLRouter
-from channels.security.websocket import AllowedHostsOriginValidator
-import participants.routing  # 이제 이 코드는 안전하게 실행될 수 있습니다.
+from django.core.asgi import get_asgi_application
+from auth.jwt_auth_middleware import JWTAuthMiddleware
+
+import participants.routing
 
 # 환경변수 설정
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'golbang.settings')
@@ -24,22 +22,11 @@ django_asgi_app = get_asgi_application()
 
 application = ProtocolTypeRouter({
     "http": django_asgi_app,
-    "websocket": AllowedHostsOriginValidator(
+    "websocket": JWTAuthMiddleware(
+        # AllowedHostsOriginValidator( 웹이랑 연결할 때는 사용함
         URLRouter(
             participants.routing.websocket_urlpatterns
         )
+        # )
     ),
 })
-'''
-application = ProtocolTypeRouter({
-    "http": django_asgi_app,
-    "websocket":
-        AuthMiddlewareStack(
-            AllowedHostsOriginValidator(
-            URLRouter(
-                participants.routing.websocket_urlpatterns
-            )
-        ),
-    ),
-})
-'''

--- a/golbang/asgi.py
+++ b/golbang/asgi.py
@@ -8,9 +8,38 @@ https://docs.djangoproject.com/en/5.0/howto/deployment/asgi/
 """
 
 import os
-
 from django.core.asgi import get_asgi_application
 
+# channels 라우팅과 미들웨어는 Django 초기화 이후에 가져와야 합니다.
+from channels.auth import AuthMiddlewareStack
+from channels.routing import ProtocolTypeRouter, URLRouter
+from channels.security.websocket import AllowedHostsOriginValidator
+import participants.routing  # 이제 이 코드는 안전하게 실행될 수 있습니다.
+
+# 환경변수 설정
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'golbang.settings')
 
-application = get_asgi_application()
+# Django ASGI 애플리케이션 초기화
+django_asgi_app = get_asgi_application()
+
+application = ProtocolTypeRouter({
+    "http": django_asgi_app,
+    "websocket": AllowedHostsOriginValidator(
+        URLRouter(
+            participants.routing.websocket_urlpatterns
+        )
+    ),
+})
+'''
+application = ProtocolTypeRouter({
+    "http": django_asgi_app,
+    "websocket":
+        AuthMiddlewareStack(
+            AllowedHostsOriginValidator(
+            URLRouter(
+                participants.routing.websocket_urlpatterns
+            )
+        ),
+    ),
+})
+'''

--- a/golbang/settings.py
+++ b/golbang/settings.py
@@ -302,6 +302,23 @@ AUTH_PASSWORD_VALIDATORS = [
     },
 ]
 
+# Logging
+# DEBUG 레벨 이상의 메시지를 콘솔에 출력
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'handlers': {
+        'console': {
+            'level': 'DEBUG',
+            'class': 'logging.StreamHandler',
+        },
+    },
+    'root': {
+        'handlers': ['console'],
+        'level': 'DEBUG',
+    },
+}
+
 
 # Internationalization
 # https://docs.djangoproject.com/en/5.0/topics/i18n/

--- a/golbang/settings.py
+++ b/golbang/settings.py
@@ -7,6 +7,8 @@ golbang/settings.py
 from datetime import timedelta
 import os
 import environ
+import redis
+import urllib.parse as urlparse
 from pathlib import Path
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
@@ -61,6 +63,12 @@ DEFAULT_FILE_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
 
 # Application definition
 INSTALLED_APPS = [
+    # ==========
+    # 비동기 통신
+    # ==========
+    'channels',
+    'daphne',
+
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',
@@ -99,6 +107,17 @@ INSTALLED_APPS = [
     'drf_yasg',     # Swagger
     'storages',     # Amazon S3 (django-storages)
 ]
+# 웹 소켓을 위한 비동기 애플리케이션
+ASGI_APPLICATION = 'golbang.asgi.application'
+
+CHANNEL_LAYERS = {
+    'default': {
+        'BACKEND': 'channels_redis.core.RedisChannelLayer',
+        'CONFIG': {
+            "hosts": [(os.environ.get('REDIS_HOST', 'localhost'), 6379)],
+        },
+    },
+}
 
 AUTH_USER_MODEL = 'accounts.User' # Custom User Model
 

--- a/participants/models.py
+++ b/participants/models.py
@@ -48,7 +48,7 @@ class Participant(models.Model):
     group_type  = models.IntegerField("조 타입", choices=GroupType.choices, null=False, blank=False)
     status_type = models.CharField("상태", max_length=7, choices=StatusType.choices, default=StatusType.PENDING)
     sum_score   = models.IntegerField("총 점수", default=0) #TODO: 웹소켓으로 점수 입력할 때마다 갱신이 어려우면 제거.
-    rank        = models.IntegerField("랭킹",default=0)
+    rank        = models.IntegerField("랭킹",default=0) #TODO: 정렬 방법(sum_score or handicap_Score)에 따라 바뀌므로 없어도 될거 같음
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
 

--- a/participants/routing.py
+++ b/participants/routing.py
@@ -1,0 +1,8 @@
+from django.urls import path
+
+from participants.socket import event_consumers, group_consumers
+
+websocket_urlpatterns = [
+    path('ws/participants/<int:participant_id>/event', event_consumers.EventParticipantConsumer.as_asgi()),
+    path('ws/participants/<int:participant_id>/group', group_consumers.GroupParticipantConsumer.as_asgi()),
+]

--- a/participants/serializers.py
+++ b/participants/serializers.py
@@ -88,3 +88,13 @@ class ParticipantAutoMatchSerializer(serializers.ModelSerializer):
         elif isinstance(obj, Participant):
             return obj.club_member.user.handicap
         return None
+
+class HoleScoreSerializer(serializers.ModelSerializer):
+    participant_id = serializers.PrimaryKeyRelatedField(
+        queryset   = Participant.objects.all(),
+        source     = 'participant'
+    )
+    action = serializers.CharField(write_only=True)
+    class Meta:
+        model  = HoleScore
+        fields = ['action', 'participant_id', 'hole_number', 'score']

--- a/participants/socket/event_consumers.py
+++ b/participants/socket/event_consumers.py
@@ -149,7 +149,7 @@ class EventParticipantConsumer(AsyncWebsocketConsumer):
             'hole_number': hole_number,
             'sum_score': sum_score,
             'score_difference':score_difference,
-            'handicap_score': sum_score + user.handicap
+            'handicap_score': sum_score - user.handicap if sum_score - user.handicap > 0 else 0
             # 등수는 프론트에서... sum_score냐 handicap_score냐에 따라 정렬 방법과 순위가 달라짐
         }
 

--- a/participants/socket/event_consumers.py
+++ b/participants/socket/event_consumers.py
@@ -119,7 +119,7 @@ class EventParticipantConsumer(AsyncWebsocketConsumer):
             ])
 
             # sum_score 기준으로 정렬
-            ranks_sorted = sorted(ranks, key=lambda x: x['sum_score'], reverse=True)
+            ranks_sorted = sorted(ranks, key=lambda x: x['sum_score'], reverse=False)
 
             await self.send_json(ranks_sorted)
         except Exception as e:

--- a/participants/socket/event_consumers.py
+++ b/participants/socket/event_consumers.py
@@ -1,0 +1,126 @@
+import json
+import redis
+import logging
+import asyncio
+
+from asgiref.sync import sync_to_async
+from channels.db import database_sync_to_async
+from channels.generic.websocket import AsyncWebsocketConsumer
+
+from participants.models import Participant
+
+# Redis 클라이언트 설정
+redis_client = redis.StrictRedis(host='redis', port=6379, db=0)
+
+# 로거 설정
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+handler = logging.StreamHandler()
+formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')  # 수정된 부분
+handler.setFormatter(formatter)
+logger.addHandler(handler)
+
+
+class EventParticipantConsumer(AsyncWebsocketConsumer):
+    async def connect(self):
+        try:
+            self.participant_id = self.scope['url_route']['kwargs']['participant_id']
+            logger.debug(f'Participant ID: {self.participant_id}')
+
+            participant = await self.get_participant(self.participant_id)
+            if participant is None:
+                raise ValueError('참가자가 존재하지 않습니다.')
+
+            self.event_id = await self.get_event_id(self.participant_id)
+            logger.debug(f'Event ID: {self.event_id}')
+
+            self.group_name = self.get_event_group_name(self.event_id)
+            logger.debug(f'Group Name: {self.group_name}')
+
+            await self.channel_layer.group_add(self.group_name, self.channel_name)
+            await self.accept()
+            logger.info('WebSocket connection accepted')
+
+            # 주기적으로 스코어를 전송하는 태스크를 설정
+            self.send_task = asyncio.create_task(self.send_scores_periodically())
+            logger.debug('Started send_scores_periodically task')
+
+        except Exception as e:
+            logger.error(f'Error in connect: {e}')
+            await self.send_json({'error': str(e)})
+            await self.close()
+
+    async def disconnect(self, close_code):
+        try:
+            logger.info('Disconnecting WebSocket')
+            await self.channel_layer.group_discard(self.group_name, self.channel_name)
+            if hasattr(self, 'send_task'):
+                self.send_task.cancel()  # 주기적인 태스크 취소
+                logger.debug('Cancelled send_scores_periodically task')
+        except Exception as e:
+            logger.error(f'Error in disconnect: {e}')
+
+    @database_sync_to_async
+    def get_participant(self, participant_id):
+        try:
+            return Participant.objects.get(id=participant_id)
+        except Participant.DoesNotExist:
+            return None
+
+    @staticmethod
+    def get_event_group_name(event_id):
+        return f"event_{event_id}_group_all"
+
+    @database_sync_to_async
+    def get_event_id(self, participant_id):
+        participant = Participant.objects.get(id=participant_id)
+        return participant.event_id
+
+    @database_sync_to_async
+    def get_all_participants(self, event_id):
+        return Participant.objects.filter(event_id=event_id)
+
+    async def send_scores(self, participant_id_list):
+        try:
+            all_scores = []
+            for participant_id in participant_id_list:
+                hole_scores = await self.get_all_hole_scores_from_redis(participant_id)
+                all_scores.append({
+                    'participant_id': participant_id,
+                    'scores': hole_scores
+                })
+            await self.send_json(all_scores)
+        except Exception as e:
+            await self.send_json({'error': '스코어 기록을 가져오는 데 실패했습니다.'})
+
+    async def send_scores_periodically(self):
+        logger.info('send_scores_periodically started')
+        while True:
+            try:
+                logger.info('Fetching participants...')
+                participants = await self.get_all_participants(self.event_id)
+                participants_list = await sync_to_async(list)(participants.values_list('id', flat=True))
+                logger.info('participants_list', participants_list)
+                await self.send_scores(participants_list)
+            except Exception as e:
+                logger.error(f'Error in send_scores_periodically: {e}')
+                await self.send_json({'error': '주기적인 스코어 전송 실패', 'details': str(e)})
+            await asyncio.sleep(10)  # 10초마다 주기적으로 스코어 전송
+
+    async def get_all_hole_scores_from_redis(self, participant_id):
+        logger.info('Fetching hole scores from Redis')
+        keys_pattern = f'participant:{participant_id}:hole:*'
+        keys = await sync_to_async(redis_client.keys)(keys_pattern)
+        logger.debug(f'Keys: {keys}')
+        hole_scores = []
+        for key in keys:
+            logger.debug(f'Processing key: {key}')
+            hole_number = int(key.decode('utf-8').split(':')[-1])
+            score = int(await sync_to_async(redis_client.get)(key))
+            logger.debug(f'Hole number: {hole_number}, score: {score}')
+            hole_scores.append({'hole_number': hole_number, 'score': score})
+        return hole_scores
+
+    async def send_json(self, content):
+        logger.debug(f'Sending JSON: {content}')
+        await self.send(text_data=json.dumps(content))

--- a/participants/socket/group_consumers.py
+++ b/participants/socket/group_consumers.py
@@ -1,0 +1,222 @@
+import json
+import redis
+import logging
+import asyncio
+from channels.generic.websocket import AsyncWebsocketConsumer
+from channels.db import database_sync_to_async
+from asgiref.sync import sync_to_async
+from events.models import Event
+from participants.models import Participant, HoleScore
+
+# Redis 클라이언트 설정
+redis_client = redis.StrictRedis(host='redis', port=6379, db=0)
+
+# 로거 설정
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+handler = logging.StreamHandler()
+formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+handler.setFormatter(formatter)
+logger.addHandler(handler)
+
+
+class GroupParticipantConsumer(AsyncWebsocketConsumer):
+    async def connect(self):
+        try:
+            self.participant_id = self.scope['url_route']['kwargs']['participant_id']
+            participant = await self.get_participant(self.participant_id)
+            if participant is None:
+                await self.close_with_status(404, 'Participant not found')
+                return
+
+            self.group_type = participant.group_type
+            self.event_id = await self.get_event_id(participant)
+            if not await self.check_event_exists(self.event_id):
+                await self.close_with_status(404, 'Event not found')
+                return
+
+            self.group_name = self.get_group_name(self.event_id)
+
+            await self.channel_layer.group_add(self.group_name, self.channel_name)
+            await self.accept()
+
+            # 주기적으로 스코어를 전송하는 태스크를 설정
+            self.send_task = asyncio.create_task(self.send_scores_periodically())
+
+        except ValueError as e:
+            await self.close_with_status(500, str(e))
+
+    async def disconnect(self, close_code):
+        try:
+            await self.channel_layer.group_discard(self.group_name, self.channel_name)
+            await self.transfer_scores_to_mysql()
+            self.send_task.cancel()  # 주기적인 태스크 취소
+        except Exception as e:
+            pass
+
+    async def receive(self, text_data):
+        try:
+            text_data_json = json.loads(text_data)
+
+            self.participant_id = text_data_json['participant_id']
+            hole_number = text_data_json['hole_number']
+            score = text_data_json['score']
+
+            participant = await self.get_participant(self.participant_id)
+            if not participant:
+                await self.send_json(self.handle_404_not_found('Participant', self.participant_id))
+                return
+
+            if hole_number is None or score is None:
+                await self.send_json({'status': 400, 'message': "Both hole number and score are required."})
+                return
+
+            await self.update_hole_score_in_redis(self.participant_id, hole_number, score)
+            await self.update_participant_sum_score(self.participant_id)
+
+            await self.channel_layer.group_send(self.group_name, {
+                'type': 'input_score',
+                'participant_id': self.participant_id,
+                'hole_number': hole_number,
+                'score': score,
+                'sum_score': participant.sum_score,
+            })
+        except ValueError as e:
+            await self.send_json({'status': 400, 'message': str(e)})
+
+    @staticmethod
+    def get_group_name(event_id):
+        return f"event_room_{event_id}"
+
+    async def close_with_status(self, code, message):
+        await self.send_json({'status': code, 'message': message})
+        await self.close(code=code)
+
+    def handle_404_not_found(self, model_name, pk):
+        return {
+            'status': 404,
+            'message': f'{model_name} {pk} is not found'
+        }
+
+    async def update_hole_score_in_redis(self, participant_id, hole_number, score):
+        key = f'participant:{participant_id}:hole:{hole_number}'
+        await sync_to_async(redis_client.set)(key, score)
+        await sync_to_async(redis_client.expire)(key, 259200)  # 3일(259200초) 후에 자동으로 삭제되도록 TTL 설정
+
+    async def update_participant_sum_score(self, participant_id):
+        keys_pattern = f'participant:{participant_id}:hole:*'
+        keys = await sync_to_async(redis_client.keys)(keys_pattern)
+
+        sum_score = 0
+        for key in keys:
+            score = await sync_to_async(redis_client.get)(key)
+            sum_score += int(score)
+
+        await self.update_participant_sum_score_in_db(participant_id, sum_score)
+
+    async def input_score(self, event):
+        try:
+            participant_id = event['participant_id']
+            hole_number = event['hole_number']
+            score = event['score']
+            sum_score = event['sum_score']
+            await self.send_json({'participant_id': participant_id, 'hole_number': hole_number, 'score': score, 'sum_score': sum_score})
+        except Exception as e:
+            await self.send_json({'error': '메시지 전송 실패'})
+
+    async def transfer_scores_to_mysql(self):
+        keys_pattern = f'participant:{self.participant_id}:hole:*'
+        keys = await sync_to_async(redis_client.keys)(keys_pattern)
+
+        async def update_or_create_hole_score(key):
+            hole_number = int(key.decode('utf-8').split(':')[-1])
+            score = int(await sync_to_async(redis_client.get)(key))
+
+            await self.update_or_create_hole_score_in_db(self.participant_id, hole_number, score)
+
+        await asyncio.gather(*(update_or_create_hole_score(key) for key in keys))
+
+    async def send_scores(self, participant_id_list):
+        try:
+            all_scores = []
+            logger.info('send_Scores')
+            for participant_id in participant_id_list:
+                hole_scores = await self.get_all_hole_scores_from_redis(participant_id)
+                logger.info('hole_scores: %s', hole_scores)
+                all_scores.append({
+                    'participant_id': participant_id,
+                    'scores': hole_scores
+                })
+            await self.send_json(all_scores)
+        except Exception as e:
+            await self.send_json({'error': '스코어 기록을 가져오는 데 실패했습니다.'})
+
+    @database_sync_to_async
+    def get_participant(self, participant_id):
+        try:
+            return Participant.objects.get(id=participant_id)
+        except Participant.DoesNotExist:
+            return None
+
+    @database_sync_to_async
+    def get_event(self, event_id):
+        try:
+            return Event.objects.get(id=event_id)
+        except Event.DoesNotExist:
+            return None
+
+    @database_sync_to_async
+    def check_event_exists(self, event_id):
+        return Event.objects.filter(id=event_id).exists()
+
+    @database_sync_to_async
+    def update_participant_sum_score_in_db(self, participant_id, sum_score):
+        Participant.objects.filter(id=participant_id).update(sum_score=sum_score)
+
+    @database_sync_to_async
+    def update_or_create_hole_score_in_db(self, participant_id, hole_number, score):
+        existing_score = HoleScore.objects.filter(participant_id=participant_id, hole_number=hole_number).first()
+        if not (existing_score and existing_score.score == score):
+            # 동일한 score가 존재하지 않거나 새로운 score로 업데이트
+            return HoleScore.objects.update_or_create(
+                participant_id=participant_id,
+                hole_number=hole_number,
+                defaults={'score': score}
+            )
+
+    @database_sync_to_async
+    def get_group_participants(self, event_id, group_type=None):
+        if group_type is None:
+            raise ValueError("Group type is missing")
+        return Participant.objects.filter(event_id=event_id, group_type=group_type)
+
+    async def get_all_hole_scores_from_redis(self, participant_id):
+        logger.info('participant_id: %s', participant_id)
+        keys_pattern = f'participant:{participant_id}:hole:*'
+        keys = await sync_to_async(redis_client.keys)(keys_pattern)
+        hole_scores = []
+        for key in keys:
+            logger.info('hole_scores: %s', hole_scores)
+            hole_number = int(key.decode('utf-8').split(':')[-1])
+            score = int(await sync_to_async(redis_client.get)(key))
+            logger.info('score: %s', score)
+            hole_scores.append({'hole_number': hole_number, 'score': score})
+        return hole_scores
+
+    @database_sync_to_async
+    def get_event_id(self, participant):
+        return participant.event.id
+
+    async def send_json(self, content):
+        await self.send(text_data=json.dumps(content))
+
+    async def send_scores_periodically(self):
+        while True:
+            try:
+                participants = await self.get_group_participants(self.event_id, self.group_type)
+                participants_list = await sync_to_async(list)(participants.values_list('id', flat=True))
+                await self.send_scores(participants_list)
+                # 왜인지 모르겠지만, participants를 넘기면 동작 안함
+            except Exception as e:
+                await self.send_json({'status': 500, 'message': str(e)})
+            await asyncio.sleep(300)  # 5분마다 주기적으로 스코어 전송

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,3 +41,13 @@ sqlparse==0.5.0
 typing_extensions==4.12.2
 uritemplate==4.1.1
 urllib3==2.2.2
+
+# 웹소켓 통신 8.6 업데이트
+channels==4.0.0
+channels-redis==4.0.0
+redis==5.0.1
+daphne==4.0.0
+
+# 추가된 패키지
+requests_mock # 테스트 환경에서 외부 HTTP 요청을 모킹하여 테스트의 일관성을 유지하고, 실제 외부 서비스를 호출하지 않도록 할 수 있다
+black>=22.3.0  #  Python 코드를 일관된 스타일로 자동 포매팅한다. 코드의 가독성을 높이고, 코드 스타일을 일관되게 유지할 수 있도록 도와준다


### PR DESCRIPTION
Issue #26 

## ✨기능
- jwt 인증 middleware 생성
- 실시간 통신시에는 score 점수가 redis db에 저장된다.
- 조별 스코어 기록/조회 
   1. 각 조의 스코어를 기록하고 조회할 수 있다. 
   2. 통신 종료시, mysql로 score를 migrate한다.
   3. action = get으로 receive 요청시, 점수 갱신이 아닌 같은 조의 전체 스코어를 반환한다.
   4. 각 참가자들은 1조부터 정렬해서 반환한다.
- 이벤트 스코어 조회
   1. 각 참가자들의 id, profile, last_hole_number, sum_score, handicap_score 들을 반환한다.
   2. 어떤 값도 안받아도 receive 요청시, event 참가자 전체 스코어를 반환한다.
   3. sum_score를 기준으로 정렬해서 반환한다.

> 참고
0. 유저 프로필 사진 필드가 user entity에 없어서 일단 이미지 url 가져오는 것은 보류했습니다

1. event/group consumers의 메서드가 너무 많아서 util로 빼려했으나 util에서 호출시 인식이 안되는 버그가 있었다.
(gpt 말로는 비동기 함수는 인스턴스나 static으로 해야한다 했는데, static도 안돼서 지금처럼 instance 형태를 유지하였다.)

2. 웹소켓 통신 에러는 기본적으로 http 에러 구현 방식과 많이 달랐다. http 에러처럼 보내려면, 웹소켓 통신이 연결된 후여야 하는데
대부분의 에러는 소켓 통신 연결 전에 발생하는 에러라 이 방법은 시도할 수 없었다. 대신, 로그를 작성하여 프론트에서 에러 발생시 로그를 확인하고 전달해야 한다. (현재 토큰 에러는 500, 참가자 not found 이런 경우 403? 이 뜰 것이다.)

3. 프론트에서 해줘야 하는 것 : 랭킹
- 0점인 참가자의 경우, 서버에서 제외하지 않았다. 이 부분을 어떻게 처리할지 좀 더 고민할 필요가 있다. (확인용으로 둘지 말지)

- 랭킹의 경우, 일반 점수와 핸디캡 점수 순위가 다르다. 서버에서는 default로 일반 점수로 정렬해서 제공하돼, 
  사진처럼 sort 요청에 따라 각 참가자들을 handicap or 일반 score로 정렬한다. 이를 프론트에서 인덱스 순서대로 랭킹을 넣어주면 된다.
<img width="433" alt="image" src="https://github.com/user-attachments/assets/0287d5b4-3347-42bb-8f11-9322051ac3df">

4. participant model에서 rank와 sum_score 필드 삭제 고민중

5. 포스트맨 소켓 통신 테스트시 주의 사항
-  아래 사진처럼 endpoint 뒤에` / `를 안붙여도 된다. 
-  토큰 전달시 Header에 `key : Authorization` `value : Bearer token`으로 보내야 한다. Bearer 뒤에 띄어쓰기 주의!
<img width="668" alt="image" src="https://github.com/user-attachments/assets/7bc154ea-14a4-4dd9-99a0-98df37269cfc">


## 🔨리팩토링 등 기타 내용
- score_difference : 현재 점수 총합 - 이전 점수 총합 = 실시간 점수 변화 필드
- handicap_score : sum_score + handicap

## 📌보완해야 할 점
- [ ] 실시간 팀전 스코어 표와 랭킹 표를 안만들었다... 개인전만 만들고 있엇다..
- [ ] 유저 프로필 이미지 필드 찾으면, event consumer 응답에 추가해야한다.