### PR TITLE
Refactor: 소켓 응답시 사용자 이름 추가 및 data class post_init 구조 통일

### DIFF
--- a/participants/stroke/data_class.py
+++ b/participants/stroke/data_class.py
@@ -17,7 +17,6 @@ class ParticipantUpdateData:
     handicap_rank: str
     sum_score: int
     handicap_score: int
-    points: int
     is_group_win: Optional[bool]
     is_group_win_handicap: Optional[bool]
 
@@ -28,6 +27,8 @@ class ParticipantUpdateData:
         if isinstance(self.handicap_rank, bytes):
             self.handicap_rank = self.handicap_rank.decode('utf-8')
         # is_group_win과 is_group_win_handicap이 bytes 타입인 경우 boolean으로 변환
+        if isinstance(self.is_group_win, bytes):
+            self.participant_id = int(self.participant_id)
         if isinstance(self.is_group_win, bytes):
             self.is_group_win = bool(int(self.is_group_win))
         if isinstance(self.is_group_win_handicap, bytes):
@@ -63,34 +64,62 @@ class RankResponseData:
     handicap_score: int
 
     def __post_init__(self):
-        # rank와 handicap_rank가 bytes 타입인 경우 문자열로 디코딩
+        if isinstance(self.participant_id, bytes):
+            self.participant_id = int(self.participant_id)
+        if isinstance(self.last_hole_number, bytes):
+            self.last_hole_number = int(self.last_hole_number)
+        if isinstance(self.last_score, bytes):
+            self.last_score = int(self.last_score)
         if isinstance(self.rank, bytes):
             self.rank = self.rank.decode('utf-8')
         if isinstance(self.handicap_rank, bytes):
             self.handicap_rank = self.handicap_rank.decode('utf-8')
+        if isinstance(self.sum_score, bytes):
+            self.sum_score = int(self.sum_score)
+        if isinstance(self.handicap_score, bytes):
+            self.handicap_score = int(self.handicap_score)
 
 @dataclass
 class ParticipantResponseData:
     participant_id: int
+    user_name: chr
     group_type: chr
     team_type: chr
     is_group_win: Optional[bool]
     is_group_win_handicap: Optional[bool]
-    hole_number: int
-    score: int
-    sum_score: int
-    handicap_score: int
+    hole_number: int = 0
+    score: int = 0
+    sum_score: int = 0
+    handicap_score: int = 0
+    rank: str = 'N/A'
+    handicap_rank: str = 'N/A'
 
     def __post_init__(self):
         # 필드들이 bytes 타입인 경우 적절한 타입으로 변환
+        if isinstance(self.participant_id, bytes):
+            self.participant_id = int(self.participant_id)
+        if isinstance(self.user_name, bytes):
+            self.user_name = self.user_name.decode('utf-8')
         if isinstance(self.group_type, bytes):
             self.group_type = self.group_type.decode('utf-8')
         if isinstance(self.team_type, bytes):
             self.team_type = self.team_type.decode('utf-8')
+        if isinstance(self.rank, bytes):
+            self.rank = self.rank.decode('utf-8')
+        if isinstance(self.handicap_rank, bytes):
+            self.handicap_rank = self.handicap_rank.decode('utf-8')
+        if isinstance(self.sum_score, bytes):
+            self.sum_score = int(self.sum_score)
+        if isinstance(self.handicap_score, bytes):
+            self.handicap_score = int(self.handicap_score)
         if isinstance(self.is_group_win, bytes):
             self.is_group_win = bool(int(self.is_group_win))
         if isinstance(self.is_group_win_handicap, bytes):
             self.is_group_win_handicap = bool(int(self.is_group_win_handicap))
+        if isinstance(self.hole_number, bytes):
+            self.hole_number = int(self.hole_number)
+        if isinstance(self.score, bytes):
+            self.score = int(self.score)
 
 
 @dataclass
@@ -105,6 +134,8 @@ class ParticipantRedisData:
 
     def __post_init__(self):
         # 필드들이 bytes 타입인 경우 적절한 타입으로 변환
+        if isinstance(self.participant_id, bytes):
+            self.participant_id = int(self.participant_id)
         if isinstance(self.group_type, bytes):
             self.group_type = self.group_type.decode('utf-8')
         if isinstance(self.team_type, bytes):
@@ -113,3 +144,7 @@ class ParticipantRedisData:
             self.is_group_win = bool(int(self.is_group_win))
         if isinstance(self.is_group_win_handicap, bytes):
             self.is_group_win_handicap = bool(int(self.is_group_win_handicap))
+        if isinstance(self.sum_score, bytes):
+            self.sum_score = int(self.sum_score)
+        if isinstance(self.handicap_score, bytes):
+            self.handicap_score = int(self.handicap_score)


### PR DESCRIPTION
## 🔨리팩토링 등 기타 내용
- 웹소켓에서도 스코어 카드 조회시 participant_id만 반환이 돼서 user_name 필드를 추가하였습니다.
- data class post_init 구조도 모든 필드에 대해서 byte 자료형인 경우를 추가하였습니다.
