### PR TITLE
Fix: 유저가 속한 조를 반환하지 않던 로직 변경

### DIFF
--- a/events/serializers.py
+++ b/events/serializers.py
@@ -97,7 +97,8 @@ class EventDetailSerializer(serializers.ModelSerializer):
                   'user_id', 'date', 'status_type']
 
     def get_my_participant_id(self, obj):
-        return obj.participant_set.filter(club_member__user=self.context['request'].user).first().id
+        self.my_participant_id = obj.participant_set.filter(club_member__user=self.context['request'].user).first().id
+        return self.my_participant_id
     def get_participants_count(self, obj):
         return obj.participant_set.count()
     def get_party_count(self, obj):
@@ -109,7 +110,7 @@ class EventDetailSerializer(serializers.ModelSerializer):
     def get_pending_count(self, obj):
         return obj.participant_set.filter(status_type="PENDING").count()
     def get_member_group(self, obj):
-        return self.context.get('group_type')
+        return obj.participant_set.filter(id=self.my_participant_id).first().group_type
 
 class UserResultSerializer(serializers.ModelSerializer):
     # 사용자의 스트로크와 순위를 계산하여 반환하는 시리얼라이저


### PR DESCRIPTION
Event의 member_group은
유저 자신이 속한 조를 반환하는 필드인데,
지금까지 null을 반환하는 잘못된 상태였습니다.

그래서, 사진처럼 출력되도록 수정하였습니다
<img width="425" alt="image" src="https://github.com/user-attachments/assets/6b311941-8bbf-4f3f-a3f3-12ce0b905630">
