### PR TITLE
Feat: 이벤트 랭킹 조회시 0점 참가자는 제외해서 응답

### DIFF
--- a/participants/stroke/redis_interface.py
+++ b/participants/stroke/redis_interface.py
@@ -51,6 +51,9 @@ class RedisInterface:
 
         participants = await self.get_participants_from_redis(event_id)
 
+        # sum_score이 0인 참가자들은 제외
+        participants = [p for p in participants if p.sum_score != 0]
+
         sorted_by_sum_score = sorted(participants, key=lambda p: p.sum_score)
         sorted_by_handicap_score = sorted(participants, key=lambda p: p.handicap_score)
 


### PR DESCRIPTION
### 참고
> 지금 올리는 커밋은 참가자 sum_score가 0이거나 (미입력된 경우) 랭킹에서 제외하는 로직만 추가한거라
원래라면 이 로직이 없는 경우, 스코어가 0인 친구들도 보여야 하는게 맞는데....
> 
> 데모시연 때는 그것조차 안됐어서 좀 다른 문제인거 같기도 하네요.. 근데 일단 제 로컬에서는
아래 사진처럼 전체현황에서 기능들이 다 동작하기 때문에 올려봅니다
<img width="322" alt="image" src="https://github.com/user-attachments/assets/cb29368c-fb1e-4359-8029-3f62ebaf87d0">
