### PR TITLE
Hotfix: 회원가입 2단계 시리얼라이저에 fcm_token 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ gb_env
 gbvenv
 /venv/
 golbang-venv
+serviceAccountKey.json

--- a/accounts/forms.py
+++ b/accounts/forms.py
@@ -46,7 +46,7 @@ class UserCreationSecondStepForm(forms.ModelForm):
     class Meta:
          # 폼에 포함할 모델과 필드
         model   = User
-        fields  = ['name', 'phone_number', 'handicap', 'date_of_birth', 'address', 'student_id']
+        fields  = ['name', 'phone_number', 'handicap', 'date_of_birth', 'address', 'student_id', 'fcm_token']
 
 '''
 사용자 수정 폼


### PR DESCRIPTION
## #️⃣연관된 이슈
> #55 


### ✨기능 추가
- 16dcb2accbfa1c8057da5899ebeb1df056feef3b: 회원가입 2단계 시, fcm_token을 요청받도록 시리얼라이저에 추가했습니다.

### 🙈 기타(ex..gitignore 추가/수정)
- 129a894166deb37665caaf619c871e45381922cc: fcm에서 사용하는 serviceAccouintKey를 .gitignore에 추가했습니다. 이 serviceAccountKey는 디코 아카이브에 올려두겠습니다!