### PR TITLE
Hotfix: UserInfo 시리얼라이저 fcm_token 포함으로 수정 및 FCM key파일 적용(임시 키파일 디코에 올림)

### DIFF
--- a/accounts/serializers.py
+++ b/accounts/serializers.py
@@ -25,7 +25,7 @@ class UserInfoSerializer(serializers.ModelSerializer):
         model = get_user_model()
         fields = (
             'id', 'user_id', 'profile_image', 'name', 'email', 'phone_number',
-            'handicap', 'address', 'date_of_birth', 'student_id'
+            'handicap', 'address', 'date_of_birth', 'student_id', 'fcm_token'
         )
 # 다른 사용자 정보 조회 시리얼라이저
 class OtherUserInfoSerializer(serializers.ModelSerializer):

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,7 @@ services:     # 컨테이너 지정
       - "8000:8000"
     env_file: #
       - .env
+      - ./golbang_firebase_sdk.json # Firebase Admin SDK 키 파일
 
   db:
     container_name: db

--- a/golbang/settings.py
+++ b/golbang/settings.py
@@ -46,7 +46,7 @@ DEBUG = True # 프로덕션 환경에서는 False로 해야 함
 ALLOWED_HOSTS = ['localhost', '127.0.0.1', '10.0.2.2']
 
 # FCM
-cred_path = os.path.join(BASE_DIR, "serviceAccountKey.json")
+cred_path = os.path.join(BASE_DIR, "golbang_firebase_sdk.json")
 cred = credentials.Certificate(cred_path)
 firebase_admin.initialize_app(cred)
 
@@ -372,3 +372,23 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/5.0/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+
+
+# https://hyun-am-coding.tistory.com/entry/Django-FCM-개발DRF
+# DOCKER 사용시 FCM key 설정 방법
+
+# service_account_key = {
+#     "type": env("TYPE"),
+#     "project_id": env("PROJECT_ID"),
+#     "private_key_id": env("PRIVATE_KEY_ID"),
+#     "private_key": env("PRIVATE_KEY").replace("\\\\n", "\\n"),
+#     "client_email": env("CLIENT_EMAIL"),
+#     "client_id": env("CLIENT_ID"),
+#     "auth_uri": env("AUTH_URI"),
+#     "token_uri": env("TOKEN_URI"),
+#     "auth_provider_x509_cert_url": env("AUTH_PROVIDER_X509_CERT_URL"),
+#     "client_x509_cert_url": env("CLIENT_X_509_CERT_URL"),
+# }
+
+# cred = credentials.Certificate(service_account_key)
+# firebase_admin.initialize_app(cred)


### PR DESCRIPTION
## 📝작업 내용
- Frontend 단에서 FCM 적용을 위해 몇 가지를 수정하였습니다.
- 시리얼라이저가 fcm_token 포함하도록 수정
- Firebase sdk 임시 키파일 생성 및 디스코드에 게시 (golbang_firebase_sdk.json)
- docker-compose 파일에서 golbang_firebase_sdk.json 파일을 env_file로 포함하도록 추정
- https://learntosurf.notion.site/1018-FCM-53dd77a247404dd089b005b78818a324?pvs=4

### 🔧 구성 파일 추가
- golbang_firebase_sdk.json
