### PR TITLE
Hotfix: 로그인 시 fcm_token을 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ gbvenv
 /venv/
 golbang-venv
 serviceAccountKey.json
+golbang_firebase_sdk.json

--- a/accounts/forms.py
+++ b/accounts/forms.py
@@ -46,7 +46,7 @@ class UserCreationSecondStepForm(forms.ModelForm):
     class Meta:
          # 폼에 포함할 모델과 필드
         model   = User
-        fields  = ['name', 'phone_number', 'handicap', 'date_of_birth', 'address', 'student_id', 'fcm_token']
+        fields  = ['name', 'phone_number', 'handicap', 'date_of_birth', 'address', 'student_id']
 
 '''
 사용자 수정 폼

--- a/accounts/serializers.py
+++ b/accounts/serializers.py
@@ -25,7 +25,7 @@ class UserInfoSerializer(serializers.ModelSerializer):
         model = get_user_model()
         fields = (
             'id', 'user_id', 'profile_image', 'name', 'email', 'phone_number',
-            'handicap', 'address', 'date_of_birth', 'student_id', 'fcm_token'
+            'handicap', 'address', 'date_of_birth', 'student_id'
         )
 # 다른 사용자 정보 조회 시리얼라이저
 class OtherUserInfoSerializer(serializers.ModelSerializer):

--- a/auth/api.py
+++ b/auth/api.py
@@ -1,6 +1,6 @@
 '''
-MVP demo ver 0.0.4
-2024.07.27
+MVP demo ver 0.0.5
+2024.10.21
 auth/api.py
 
 역할: DRF REST API
@@ -38,6 +38,7 @@ class LoginApi(APIView):
         # 요청 데이터로부터 이메일 또는 아이디가 들어간 username필드와 비밀번호 가져옴
         username_or_email   = request.data.get('username')
         password            = request.data.get('password')
+        fcm_token           = request.data.get('fcm_token')
 
         # 이메일이나 비밀번호가 없을 경우 -> 400 bad request 응답
         if (username_or_email is None) or (password is None):
@@ -61,6 +62,12 @@ class LoginApi(APIView):
                 "status" : status.HTTP_400_BAD_REQUEST,
                 "message": "Passwords do not match"
             }, status=status.HTTP_400_BAD_REQUEST)
+
+        # FCM 토큰이 비어 있거나 다르면 업데이트
+        if fcm_token:
+            if user.fcm_token != fcm_token:
+                user.fcm_token = fcm_token
+                user.save()
 
         refresh         = RefreshToken.for_user(user)
         access_token    = str(refresh.access_token)


### PR DESCRIPTION
## #️⃣연관된 이슈
> #55


## 📝작업 내용
> 정리한 노션이 있다면 추가해주세요.
- [1018 회의록 - FCM 관련](https://learntosurf.notion.site/1018-FCM-53dd77a247404dd089b005b78818a324?pvs=4)

### ✨기능 추가
- 회원가입 및 사용자 조회 시 fcm_token을 받아오거나 보내주는 시리얼라이저에서 fcm_token 제거
- 로그인 시 FCM 토큰을 처리하는 방식으로 변경함
   - **FCM 토큰이 없는 경우**: 로그인 시 FCM 토큰이 비어 있다면 새로 발급받아서 사용자 정보에 저장한다.
   - **FCM 토큰이 다른 경우**: 만약 로그인할 때 받아온 FCM 토큰이 기존의 토큰과 다르다면, 새로운 토큰으로 업데이트한다. 

### 🙈 기타(ex..gitignore 추가/수정)
- 이전에 중범선배가 올려주신 `golbang_firebase_sdk.json`을 추가해두었습니다.
