### PR TITLE
Feat: 관리자 계정 자동화 스크립트 추가 및 EC2 IP를 장고 호스트 허용 등록

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,4 +35,8 @@ ENV DJANGO_SETTINGS_MODULE=golbang.settings
 EXPOSE 8000
 
 # 명령어 설정
-CMD ["/wait-for-it.sh", "db:3306", "--", "/wait-for-it.sh", "redis:6379", "--", "sh", "-c", "python manage.py makemigrations && python manage.py migrate && python manage.py runserver 0.0.0.0:8000"]
+CMD ["/wait-for-it.sh", "db:3306", "--", "/wait-for-it.sh", "redis:6379", "--", "sh", "-c", "\
+    python manage.py makemigrations && \
+    python manage.py migrate && \
+    python manage.py runserver 0.0.0.0:8000 && \
+    python create-superuser.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,5 +38,5 @@ EXPOSE 8000
 CMD ["/wait-for-it.sh", "db:3306", "--", "/wait-for-it.sh", "redis:6379", "--", "sh", "-c", "\
     python manage.py makemigrations && \
     python manage.py migrate && \
-    python manage.py runserver 0.0.0.0:8000 && \
-    python create-superuser.py"]
+    python create-superuser.py && \
+    python manage.py runserver 0.0.0.0:8000"]

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -35,4 +35,8 @@ ENV DJANGO_SETTINGS_MODULE=golbang.settings
 EXPOSE 8000
 
 # 명령어 설정
-CMD ["/wait-for-it.sh", "redis:6379", "--", "sh", "-c", "python manage.py makemigrations && python manage.py migrate && python manage.py runserver 0.0.0.0:8000"]
+CMD ["/wait-for-it.sh", "redis:6379", "--", "sh", "-c", "\
+    python manage.py makemigrations && \
+    python manage.py migrate && \
+    python create-superuser.py && \
+    python manage.py runserver 0.0.0.0:8000"]

--- a/accounts/models.py
+++ b/accounts/models.py
@@ -13,7 +13,7 @@ from django.contrib.auth.models import (BaseUserManager, AbstractBaseUser)
 # AbstractBaseUser: 실제 모델은 상속받아 생성
 class UserManager(BaseUserManager):
 
-    def create_user(self, email, user_id, password=None, **extra_fields):
+    def create_user(self, user_id, email,  password=None, **extra_fields):
         if not email:
             raise ValueError('Users must have an email address')
         if not user_id:
@@ -30,18 +30,18 @@ class UserManager(BaseUserManager):
         user.save(using=self._db)
         return user
 
-    def create_superuser(self, email, user_id, password=None, **extra_fields):
+    def create_superuser(self, user_id, email, password=None, **extra_fields):
         extra_fields.setdefault('is_admin', True)
         extra_fields.setdefault('is_active', True)
 
-        return self.create_user(email, user_id, password, **extra_fields)
+        return self.create_user(user_id, email, password, **extra_fields)
 
 
 class User(AbstractBaseUser):
     # step 1
     user_id     = models.CharField("사용자 아이디", unique=True, max_length=150, default='unknown_user')
-    password    = models.CharField("비밀번호", max_length=256, null=True, blank=True) # # Oauth 로그인을 위해 비밀번호 빈 값 허용
     email       = models.EmailField("이메일", unique=True)
+    password    = models.CharField("비밀번호", max_length=256, null=True, blank=True) # # Oauth 로그인을 위해 비밀번호 빈 값 허용
     login_type  = models.CharField(max_length=10, choices=[('general', 'General'), ('social', 'Social')], default='general')
     provider    = models.CharField(max_length=50, null=True, blank=True)
     

--- a/create-superuser.py
+++ b/create-superuser.py
@@ -1,0 +1,29 @@
+# create_superuser.py
+import os
+import django
+from django.contrib.auth import get_user_model
+
+# Django 환경 설정
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'golbang.settings')
+django.setup()
+
+User = get_user_model()
+
+def create_superuser(username, email, password):
+    if User.objects.filter(email=email).exists():
+        print('Superuser already exists')
+    else:
+        User.objects.create_superuser(user_id=username, email=email, password=password)
+        print('Superuser created successfully')
+
+if __name__ == '__main__':
+    # 환경 변수에서 이메일, 사용자 ID, 비밀번호 가져오기
+    email = os.getenv("DJANGO_SUPERUSER_EMAIL")
+    password = os.getenv("DJANGO_SUPERUSER_PASSWORD")
+    username = os.getenv("DJANGO_SUPERUSER_USERNAME")  # 기본 슈퍼유저 ID
+
+    # 이메일과 비밀번호가 제공되었는지 확인
+    if email and password and username:
+        create_superuser(username, email, password)
+    else:
+        print("Environment variables DJANGO_SUPERUSER_EMAIL, DJANGO_SUPERUSER_PASSWORD, and DJANGO_SUPERUSER_ID are required.")

--- a/golbang/settings.py
+++ b/golbang/settings.py
@@ -43,7 +43,7 @@ MAIN_DOMAIN = env('MAIN_DOMAIN')
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True # 프로덕션 환경에서는 False로 해야 함
 
-ALLOWED_HOSTS = ['localhost', '127.0.0.1', '10.0.2.2']
+ALLOWED_HOSTS = ['localhost', '127.0.0.1', '10.0.2.2', os.getenv("AWS_HOST_IP")]
 
 # FCM
 # cred_path = os.path.join(BASE_DIR, "golbang_firebase_sdk.json")


### PR DESCRIPTION
### ✨기능 추가
혹시, DB가 초기화 될 경우, 관리자 계정을 새로 만드는 것이 번거롭기 때문에, 
컨테이너 실행시 관리자 계정을 자동으로 만드는 스크립트를 구현했습니다.

### ♻ 코드 리팩토링
User의 createSuperUser부분이 일반적으로 username, email, password 순서라 해서( GPT의견 )
기존 email, user, password 파라미터 순서를 바꾸었습니다.

### 🔧 구성 파일 추가
EC2 IP로 관리자 페이지 접속시 권한이 없다고 나와서
HOST ALLOWED IP에  EC2 IP추가했습니다.

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
좀 특이한데, web, db 볼륨을 마운트하면 createsuperuser 스크립트가 안먹히더라구요.
그래서, 로컬에서는 ines 관리자 계정이 안될거에요. 
CI/CD 도커 컴포즈에서는 볼륨을 다른 버그때문에 제외했어서 될겁니다~

환경변수 추가되었습니다.
관리자계정 및 EC2 IP 환경변수 추가했어요

