### PR TITLE
Hotfix: 파이어베이스 환경변수 불러오는 스크립트 추가 및 체크아웃 깃 액션 버전 업그레이드

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,13 +13,16 @@ jobs:
       SECRET_KEY: ${{ secrets.SECRET_KEY }}  # SECRET_KEY를 직접 설정
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Docker Compose
         run: |
           sudo curl -L "https://github.com/docker/compose/releases/download/$(curl -s https://api.github.com/repos/docker/compose/releases/latest | jq -r .tag_name)/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
           sudo chmod +x /usr/local/bin/docker-compose
           docker-compose --version  # 설치 확인
+      
+      - name: Save JSON data from secret to file
+        run:  echo '${{ secrets.FIREBASE_SDK_JSON }}' > golbang-test-31a73-firebase-adminsdk-wqtgg-f611444c79.json
 
       - name: Create .env file from SERVER_ENV_FILE secret
         run: |


### PR DESCRIPTION
## 📌보완해야 할 점 (선택)
1. 지금 보니 COPY ..에서 컨테이너 내부에 코드만 복사되는게 아닌 도커 컴포즈 파일도 복사되더라구요.
도커 이그노어를 통해 코드만 복사 가능한지 나중에 찾아봐야될 것 같습니다.

2.  도커 로그인 아이디 비번 따로 깃 시크릿으로 분리해, 스크립트 간소화하기
