### PR TITLE
Feat: 이벤트/모임/알림 기능 관련하여 프론트엔드 요청사항 반영

### DIFF
--- a/clubs/tasks.py
+++ b/clubs/tasks.py
@@ -67,7 +67,7 @@ def send_club_creation_notification(club_id):
 
         # FCM 메시지 전송
         if fcm_tokens:
-            send_fcm_notifications(fcm_tokens, message_title, message_body)
+            send_fcm_notifications(fcm_tokens, message_title, message_body, club_id=club.id)
             logger.info(f"모임 생성 알림 전송 성공")
         else:
             logger.info(f"No FCM tokens found for club members in club: {club}")

--- a/clubs/tasks.py
+++ b/clubs/tasks.py
@@ -63,7 +63,7 @@ def send_club_creation_notification(club_id):
 
         # 모임 이름을 포함한 메시지 생성
         message_title = f"{club.name} 모임에 초대되었습니다."  # 메시지 제목
-        message_body = f"모임이 성공적으로 생성되었습니다. {club.name} 모임에서 골프를 즐겨봅시다!"
+        message_body = f"{club.name} 모임에서 골프를 즐겨봅시다!"
 
         # FCM 메시지 전송
         if fcm_tokens:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,19 +42,19 @@ services:     # 컨테이너 지정
     volumes: # 파일 시스템 정의
       - redisdata:/data
 
-#  celery:   # celery 작업자
-#    container_name: celery
-#    build: .
-#    command: celery -A golbang worker -l info
-#    environment:
-#      DJANGO_SETTINGS_MODULE: golbang.settings
-#      REDIS_URL: redis://redis:6380/0
-#      REDIS_HOST: redis
-#    volumes:
-#      - .:/app
-#    env_file:
-#      - .env
-#
+  celery:   # celery 작업자
+    container_name: celery
+    build: .
+    command: celery -A golbang worker -l info
+    environment:
+      DJANGO_SETTINGS_MODULE: golbang.settings
+      REDIS_URL: redis://redis:6380/0
+      REDIS_HOST: redis
+    volumes:
+      - .:/app
+    env_file:
+      - .env
+
 #  celery-beat:   # 주기적으로 업데이트
 #    container_name: celery-beat
 #    build: .

--- a/events/serializers.py
+++ b/events/serializers.py
@@ -206,6 +206,7 @@ class ScoreCardSerializer(serializers.ModelSerializer):
     스코어카드 결과(그룹별 스코어 결과)를 반환하는 시리얼라이저
     """
     participant_name = serializers.CharField(source='club_member.user.name', read_only=True)
+    team = serializers.SerializerMethodField()              # 팀 정보
     front_nine_score = serializers.SerializerMethodField()  # 전반전 점수 (1~9홀)
     back_nine_score = serializers.SerializerMethodField() # 후반전 점수 (10~18홀)
     total_score = serializers.SerializerMethodField()
@@ -214,7 +215,15 @@ class ScoreCardSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Participant
-        fields = ['participant_name', 'front_nine_score', 'back_nine_score', 'total_score', 'handicap_score', 'scorecard']
+        fields = ['participant_name', 'team', 'front_nine_score', 'back_nine_score', 'total_score', 'handicap_score', 'scorecard']
+
+    def get_team(self, participant):
+        # 팀 정보를 반환
+        if participant.team_type == Participant.TeamType.TEAM1:
+            return "Team A"
+        elif participant.team_type == Participant.TeamType.TEAM2:
+            return "Team B"
+        return "No Team"
 
     def get_front_nine_score(self, participant):
         front_nine_score = HoleScore.objects.filter(participant=participant, hole_number__lte=9).aggregate(total=Sum('score'))['total']

--- a/events/tasks.py
+++ b/events/tasks.py
@@ -36,7 +36,7 @@ def send_event_creation_notification(event_id):
         message_body = f"{event.event_title} 이벤트의 날짜는 {event.start_date_time.strftime('%Y-%m-%d')}이며, 장소는 {event.site}입니다. 참석 여부를 체크해주세요."
 
         if fcm_tokens:
-            send_fcm_notifications(fcm_tokens, message_title, message_body)
+            send_fcm_notifications(fcm_tokens, message_title, message_body, event_id=event.id)
             logger.info(f"이벤트 생성 알림 전송 성공: {event.event_title}")
         else:
             logger.info(f"No FCM tokens found for club members in club: {club}")
@@ -65,7 +65,7 @@ def send_event_update_notification(event_id):
         message_body = f"수정된 {event.event_title} 이벤트의 날짜는 {event.start_date_time.strftime('%Y-%m-%d')}이며, 장소는 {event.site}입니다. 다시 참석 여부를 체크해주세요."
 
         if fcm_tokens:
-            send_fcm_notifications(fcm_tokens, message_title, message_body)
+            send_fcm_notifications(fcm_tokens, message_title, message_body, event_id=event.id)
             logger.info(f"이벤트 수정 알림 전송 성공: {event.event_title}")
         else:
             logger.info(f"No FCM tokens found for club members in club: {club}")
@@ -128,7 +128,7 @@ def send_event_notification_2_days_before():
         message_body = f"이벤트 상세 정보와 참석 여부를 확인해주세요."
 
         if fcm_tokens:
-            send_fcm_notifications(fcm_tokens, message_title, message_body)
+            send_fcm_notifications(fcm_tokens, message_title, message_body, event_id=event.id)
             logger.info(f"이틀 전 알림 전송 성공: {event.event_title}")
         else:
             logger.info(f"No FCM tokens found for club members in club: {club}")
@@ -149,7 +149,7 @@ def send_event_notification_1_hour_before():
         message_body = f"이벤트 상세 정보와 참석 여부를 확인해주세요."
 
         if fcm_tokens:
-            send_fcm_notifications(fcm_tokens, message_title, message_body)
+            send_fcm_notifications(fcm_tokens, message_title, message_body, event_id=event.id)
             logger.info(f"1시간 전 알림 전송 성공: {event.event_title}")
         else:
             logger.info(f"No FCM tokens found for club members in club: {club}")
@@ -170,7 +170,7 @@ def send_event_notification_event_ended():
         message_body = f"이벤트 결과를 확인해주세요. (스코어 점수 수정은 이벤트 종료 2일 후까지만 가능합니다)"
 
         if fcm_tokens:
-            send_fcm_notifications(fcm_tokens, message_title, message_body)
+            send_fcm_notifications(fcm_tokens, message_title, message_body, event_id=event.id)
             logger.info(f"이벤트 종료 알림 전송 성공: {event.event_title}")
         else:
             logger.info(f"No FCM tokens found for club members in club: {club}")

--- a/events/tasks.py
+++ b/events/tasks.py
@@ -33,7 +33,7 @@ def send_event_creation_notification(event_id):
         logger.info(f"Retrieved FCM tokens for event creation: {fcm_tokens}")
 
         message_title = f"{club.name} 모임에서 이벤트가 생성되었습니다."
-        message_body = f"{event.event_title} 이벤트의 날짜는 {event.start_date_time.strftime('%Y-%m-%d')}이며, 장소는 {event.site}입니다. 참석 여부를 체크해주세요."
+        message_body = f"이벤트: {event.event_title}\n날짜: {event.start_date_time.strftime('%Y-%m-%d')}\n장소: {event.site}\n참석 여부를 체크해주세요."
 
         if fcm_tokens:
             send_fcm_notifications(fcm_tokens, message_title, message_body, event_id=event.id)
@@ -62,7 +62,7 @@ def send_event_update_notification(event_id):
 
 
         message_title = f"{club.name} 모임에서 이벤트가 수정되었습니다."
-        message_body = f"수정된 {event.event_title} 이벤트의 날짜는 {event.start_date_time.strftime('%Y-%m-%d')}이며, 장소는 {event.site}입니다. 다시 참석 여부를 체크해주세요."
+        message_body = f"수정된 이벤트: {event.event_title}\n날짜: {event.start_date_time.strftime('%Y-%m-%d')}\n장소: {event.site}\n다시 참석 여부를 체크해주세요."
 
         if fcm_tokens:
             send_fcm_notifications(fcm_tokens, message_title, message_body, event_id=event.id)

--- a/utils/push_fcm_notification.py
+++ b/utils/push_fcm_notification.py
@@ -42,7 +42,7 @@ def get_fcm_tokens_for_event_participants(event):
     return list(Participant.objects.filter(event=event).values_list('club_member__user__fcm_token', flat=True))
 
 
-def send_fcm_notifications(tokens, title, body):
+def send_fcm_notifications(tokens, title, body, event_id=None, club_id=None):
     '''
     주어진 FCM 토큰 리스트에 일괄적으로 푸시 알림을 전송하는 함수
 
@@ -53,7 +53,16 @@ def send_fcm_notifications(tokens, title, body):
     if not tokens:
         logger.warning("FCM 토큰이 없습니다. 알림을 전송하지 않습니다.")
         return
+
+        # 조건에 따라 data 필드 구성
+    additional_data = {}
+    if event_id:
+        additional_data["event_id"] = str(event_id)  # 이벤트 ID만 포함
+    elif club_id:
+        additional_data["club_id"] = str(club_id)  # 모임 ID만 포함
+
     logger.info(f"send_fcm_notifications 전송할 FCM 토큰: {tokens}")  # 토큰 리스트 출력
+    logger.info(f"이벤트/모임 데이터: {additional_data}")
 
     for token in tokens:
         print(f"token: {token}, type: {type(tokens)}")
@@ -61,6 +70,7 @@ def send_fcm_notifications(tokens, title, body):
     for token in tokens:
         # 개별 메시지 객체 생성
         message = messaging.Message(
+            data=additional_data,# 이벤트/모임 id 필ㅂ1
             notification=messaging.Notification(title=title, body=body),
             token=token,
         )


### PR DESCRIPTION
## #️⃣연관된 이슈

> resolved #70 - 이벤트/모임/알림 기능 관련하여 프론트엔드 요청사항 반영

## 참고 : 알림 기능 관련해서 프론트엔드 코드도 수정했습니다. 함께 PR 올렸습니다!

## 📝작업 내용
> 정리한 노션이 있다면 추가해주세요.
- [FCM 알림 보낼 때 event 또는 club 의 id가 프론트엔드측에서 필요하다. 이를 함께 보내주도록 수정해야 한다.](https://learntosurf.notion.site/FCM-event-club-id-17aa261b9b054ac6b2f9e581fabb049a?pvs=4)
- [이벤트 결과 조회 시, 팀전인 경우 누가 어느 팀인지에 대한 정보도 함께 response로 반환해야 한다. 해당 시리얼라이저를 수정해야 한다.](https://learntosurf.notion.site/response-1e18fcab20864ea4b8d3de4a64f88435?pvs=4)
- [알림 메시지를 멀티라인으로 표시하도록 설정](https://learntosurf.notion.site/6949e52073d4467189f69b3416122ab9?pvs=4)

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
> 설명에 커밋 번호도 있다면 도움이 됩니다.

### ✨기능 추가
> **FCM 알림 기능 관련**
- 17c7e960b61ae68de07dc7281e09fe33ff275c9c: Message 클래스에 따라 data 딕셔너리 문자열 필드를 추가하여 모임/이벤트 id 값 전달 **(자세한 내용은 정리된 노션 참고)**
    - 프론트에서 id가 잘 전달되고 있는 것도 확인 완료함 
- d0512c84d4ce7d39f31682bf974bbfe66ee61eef: 알림 메시지 멀티라인을 위해 개행문자 추가 및 message_body 내용 수정 (자세한 내용은 노션 참고)

> **이벤트 결과 조회 관련**
- 98627000e4e33cb21e77a8cef0baa169d3704db5: 이벤트 결과 스코어카드 조회 시 팀 정보를 참가자 응답에 포함하도록 수정함 **(자세한 내용은 정리된 노션 참고)**
    - A팀인 경우: `Team A`, B팀인 경우: `Team B`,  개인전(팀이 없는 경우): `No Team`
    -`GET  /events/{event_id}/scores/ `(스코어카드 결과 조회) API를 수정하기 위해 `ScoreCardSerializer` 수정함. 
    - 이 내용을 반영해서 API 명세도 수정 완료함.  
    - Postman을 통해 API 응답 테스트도 완료함.

### 변경사항 요약
1. **`send_fcm_notifications`을 비롯한 알림 관련 함수**: event 또는 club id를 함께 전송하도록 추가
2. **`ScoreCardSerializer`**: 참가자 데이터에 팀 정보를 추가.
3. **테스트**: 알림 수신 시 id가 잘 전달되는지 확인 완료, 요청 시 팀 정보와 점수가 올바르게 반환되는지 확인 완료
---