### PR TITLE
Feat: 알림 내역 저장 시간 연장, 알림 저장 시 event_id, club_id 함께 저장, celery beat 작업 수정

### DIFF
--- a/clubs/tasks.py
+++ b/clubs/tasks.py
@@ -100,7 +100,7 @@ def send_club_creation_notification(club_id):
                 notification_data = {**base_notification_data, "status": "success"}
                 print(f"notification준비 완료 {notification_id}, {notification_data}")
 
-                async_to_sync(redis_interface.save_notification)(user_id, notification_id, notification_data)
+                async_to_sync(redis_interface.save_notification)(user_id, notification_id, notification_data, club_id=club.id)
         else:
             logger.info(f"No FCM tokens found for club members in club: {club}")
 

--- a/events/tasks.py
+++ b/events/tasks.py
@@ -68,7 +68,7 @@ def send_event_creation_notification(event_id):
                 notification_data = {**base_notification_data, "status": "success"}
                 print(f"notification준비 완료 {notification_id}, {notification_data}")
 
-                async_to_sync(redis_interface.save_notification)(user_id, notification_id, notification_data)
+                async_to_sync(redis_interface.save_notification)(user_id, notification_id, notification_data, event_id=event.id)
         else:
             logger.info(f"No FCM tokens found for club members in club: {club}")
 
@@ -120,7 +120,7 @@ def send_event_update_notification(event_id):
                 notification_data = {**base_notification_data, "status": "success"}
                 print(f"notification준비 완료 {notification_id}, {notification_data}")
 
-                async_to_sync(redis_interface.save_notification)(user_id, notification_id, notification_data)
+                async_to_sync(redis_interface.save_notification)(user_id, notification_id, notification_data, event_id=event.id)
 
         else:
             logger.info(f"No FCM tokens found for club members in club: {club}")
@@ -187,7 +187,7 @@ def send_event_notification_10_seconds_before(event_id):
             for user_id in user_ids:
                 notification_id = str(uuid.uuid4())
                 notification_data["notification_id"] = notification_id
-                async_to_sync(redis_interface.save_notification)(user_id, notification_id, notification_data)
+                async_to_sync(redis_interface.save_notification)(user_id, notification_id, notification_data, event_id=event.id)
 
     except Event.DoesNotExist:
         logger.error(f"Event {event_id} does not exist")
@@ -270,7 +270,7 @@ def send_event_notification_2_days_before():
                 notification_data = {**base_notification_data, "status": "success"}
                 print(f"notification준비 완료 {notification_id}, {notification_data}")
 
-                async_to_sync(redis_interface.save_notification)(user_id, notification_id, notification_data)
+                async_to_sync(redis_interface.save_notification)(user_id, notification_id, notification_data, event_id=event.id)
 
         else:
             logger.info(f"No FCM tokens found for club members in club: {club}")
@@ -316,7 +316,7 @@ def send_event_notification_1_hour_before():
                 notification_data = {**base_notification_data, "status": "success"}
                 print(f"notification준비 완료 {notification_id}, {notification_data}")
 
-                async_to_sync(redis_interface.save_notification)(user_id, notification_id, notification_data)
+                async_to_sync(redis_interface.save_notification)(user_id, notification_id, notification_data, event_id=event.id)
 
         else:
             logger.info(f"No FCM tokens found for club members in club: {club}")
@@ -361,7 +361,7 @@ def send_event_notification_event_ended():
                 notification_data = {**base_notification_data, "status": "success"}
                 print(f"notification준비 완료 {notification_id}, {notification_data}")
 
-                async_to_sync(redis_interface.save_notification)(user_id, notification_id, notification_data)
+                async_to_sync(redis_interface.save_notification)(user_id, notification_id, notification_data, event_id=event.id)
         else:
             logger.info(f"No FCM tokens found for club members in club: {club}")
 

--- a/golbang/settings.py
+++ b/golbang/settings.py
@@ -156,7 +156,7 @@ CELERY_TASK_SERIALIZER = 'json'
 CELERY_TIMEZONE = 'Asia/Seoul'
 CELERY_BEAT_SCHEDULE = {
     'update-club-rankings-every-day': {
-        'task': 'clubs.tasks.update_all_clubs_periodically',
+        'task': 'clubs.tasks.calculate_club_ranks_and_points',
         'schedule': crontab(minute=0, hour=0),  # 매일 자정에 실행
     },
 }

--- a/notifications/redis_interface.py
+++ b/notifications/redis_interface.py
@@ -24,7 +24,7 @@ class NotificationRedisInterface:
         print(f"Saving notification with key={key} and data={notification_data}")
 
         await sync_to_async(redis_client.set)(key, json.dumps(notification_data))
-        await sync_to_async(redis_client.expire)(key, 172800)  # 2일 후 만료 설정
+        await sync_to_async(redis_client.expire)(key, 604800)  # 7일 후 만료 설정
 
     async def get_notification(self, user_id, notification_id):
         """

--- a/notifications/redis_interface.py
+++ b/notifications/redis_interface.py
@@ -12,19 +12,24 @@ class NotificationRedisInterface:
     Redis와 상호작용하여 알림 데이터를 관리하는 인터페이스
     """
 
-    async def save_notification(self, user_id, notification_id, notification_data):
+    async def save_notification(self, user_id, notification_id, notification_data, event_id=None, club_id=None):
         """
         Redis에 알림 데이터를 저장합니다.
         """
         print(f"이곳은 save_notification 함수!!!!! user_id={user_id} notification_id={notification_id}, notification_data={notification_data}")
-        # 타임스탬프 추가
-        notification_data["timestamp"] = datetime.now().isoformat()
+
+        # 타임스탬프 및 event_id 또는 club_id 데이터 추가
+        notification_data.update({
+            "timestamp": datetime.now().isoformat(),
+            "event_id": event_id,
+            "club_id": club_id
+        })
         print(f"notification_data에 타임스탬프 추가 => {notification_data}")
         key = f"notification:{user_id}:{notification_id}"
         print(f"Saving notification with key={key} and data={notification_data}")
 
         await sync_to_async(redis_client.set)(key, json.dumps(notification_data))
-        await sync_to_async(redis_client.expire)(key, 604800)  # 7일 후 만료 설정
+        await sync_to_async(redis_client.expire)(key, 604800)  # 7일 후 만료
 
     async def get_notification(self, user_id, notification_id):
         """


### PR DESCRIPTION
## #️⃣연관된 이슈

> #85 


## 📝작업 내용
> 정리한 노션이 있다면 추가해주세요.
- [(백엔드) notification 관련 → 알림내역목록 네비게이션을 위해서 백엔드에서 event_id, club_id 함께 보내줘야 함](https://learntosurf.notion.site/notification-event_id-club_id-3cd342840fc34239a5301eb6152080b0?pvs=4)

### ✨기능 추가
> 알림
- a5c8f61de43d3b21f6e9bebd6d38151854c4b099: 알림 데이터를 redis에 저장하는 기간을 2일에서 7일로 늘림
- a52b2b7820fce39f90b80ffccea948dee2bd0002: 알림 내역을 redis에 저장할 때 event_id 또는 club_id를 함께 저장하도록 하여 알림 내역 반환 시 함께 반환되도록 설정

알림 내역 조회 시 아래와 같이 event_id와 club_id를 반환함. 
```json
{
    "status": 200,
    "message": "Successfully retrieved notification list",
    "data": [
        {
            "title": "notification test 모임에 초대되었습니다.",
            "body": "notification test 달력을 눌러 새로운 일정을 만들어보세요!",
            "status": "success",
            "timestamp": "2024-12-15T14:31:15.544570",
            "read": false,
            "notification_id": "f7a3e781-1c1c-420d-8402-a720bc0056d6",
            "event_id": null,
            "club_id": 90
        },
        {
            "title": "6moimtest6 모임에서 이벤트가 생성되었습니다.",
            "body": "이벤트: notificationtest\n날짜: 2024-12-23\n장소: Siem Reap Lake Resort Golf Club\n참석 여부를 체크해주세요.",
            "status": "success",
            "timestamp": "2024-12-15T14:27:45.998713",
            "read": false,
            "notification_id": "0f8d2bd4-f6a9-4078-b4fd-d40844c5b1b6",
            "event_id": 83,
            "club_id": null
        }
    ]
}
```

> 기타
- 9daba7fb29b452bcdbc3cf29f27efad377ab9cec: celery beat의 작업 함수를 참고한 블로그 함수로 설정해놓았음.. 우리한테 필요한 함수로 수정

## 참고
- 통계 API가 잘 동작하지 않는 이슈는 알고보니 `participants.participant`테이블의 `sum_score`, `handicap_score`, rank, `handicap_rank`가 redis로부터 mysql 에 제대로 저장되지 않기 때문이었음. 이 부분은 성문이가 다시 맡아 디버깅 하기로 함
- API 명세(api/v1/notifications/)에도 반영해둠
<img width="773" alt="스크린샷 2024-12-15 오후 3 36 43" src="https://github.com/user-attachments/assets/9cdeac01-afe1-40a4-984f-17b456fe21f3" />

