### PR TITLE
hotfix: 모임 나가기 api return 누락 추가

### DIFF
--- a/clubs/views/club_member.py
+++ b/clubs/views/club_member.py
@@ -90,7 +90,7 @@ class ClubMemberViewSet(ClubViewSet):
         user = request.user
         member = ClubMember.objects.filter(club=club, user=user).first()
 
-        self.common_leave_club(member, user)
+        return self.common_leave_club(member, user)
     
     @staticmethod
     def common_leave_club(member, user):


### PR DESCRIPTION

## 📝작업 내용
> 정리한 노션이 있다면 추가해주세요.
- 프론트에서 interceptor로 모임 나가기 api 리팩토링 도중, 서버 500 에러 발생. 
- 로그 분석 후, http 리스폰스 리턴이 안됨을 확인
- 누락된 return 추가
