### PR TITLE
fix: 랭킹 웹소켓에서 유저 프로필 이미지 반환하도록 추가

### DIFF
--- a/participants/stroke/stroke_event_consumers.py
+++ b/participants/stroke/stroke_event_consumers.py
@@ -137,8 +137,8 @@ class EventParticipantConsumer(AsyncWebsocketConsumer, MySQLInterface, RedisInte
 
         return {
             'user': {
-                'name': user.name
-                # TODO 'image' : 유저 프로필 사진 추가
+                'name': user.name,
+                'profile_image' : user.profile_image,
             },
             **asdict(rank_data)  # RankData 객체를 딕셔너리로 변환 후 펼침
         }


### PR DESCRIPTION
### 🐛 버그 수정
<img width="243" alt="스크린샷 2025-01-14 오전 1 33 11" src="https://github.com/user-attachments/assets/3995e0ec-a3bc-4fcf-92ac-a1ec3fa42a45" />

프론트 작업도중, 게임 랭킹 페이지에서 유저 프로필이 안뜨는 것을 확인.
이전에, s3연결 전, 유저 이미지 연결을 위해 TODO로 주석 처리한 부분을 마저 구현