### PR TITLE
hotfix: 모델 Image타입은 json 직렬이 안됨. url을 추출해서 넣어야함

### DIFF
--- a/participants/stroke/stroke_event_consumers.py
+++ b/participants/stroke/stroke_event_consumers.py
@@ -138,7 +138,7 @@ class EventParticipantConsumer(AsyncWebsocketConsumer, MySQLInterface, RedisInte
         return {
             'user': {
                 'name': user.name,
-                'profile_image' : user.profile_image,
+                'profile_image' : user.profile_image.url if user.profile_image else None,
             },
             **asdict(rank_data)  # RankData 객체를 딕셔너리로 변환 후 펼침
         }


### PR DESCRIPTION
프론트에서 게임 랭킹 조회중 서버에서 응답이 안와 로그를 보니 아래 로그를 확인함.
그에 따라 수정
```
response_data: {'event': {'group_win_team': None, 'group_win_team_handicap': None, 'total_win_team': None, 'total_win_team_handicap': None}, 'rankings': [{'user': {'name': 'Jungbeom0', 'profile_image': <ImageFieldFile: accounts/1000000019_rnJJiEL.jpg>}, 'participant_id': 239, 'last_hole_number': 2, 'last_score': 10, 'rank': '1', 'handicap_rank': '1', 'sum_score': 9, 'handicap_score': -91}]}
Sending JSON: {'event': {'group_win_team': None, 'group_win_team_handicap': None, 'total_win_team': None, 'total_win_team_handicap': None}, 'rankings': [{'user': {'name': 'Jungbeom0', 'profile_image': <ImageFieldFile: accounts/1000000019_rnJJiEL.jpg>}, 'participant_id': 239, 'last_hole_number': 2, 'last_score': 10, 'rank': '1', 'handicap_rank': '1', 'sum_score': 9, 'handicap_score': -91}]}
Error in send_json: Object of type ImageFieldFile is not JSON serializable
```