### PR TITLE
hotfix: celery에 레디스 비밀번호 환경변수 추가

### DIFF
--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -1,5 +1,3 @@
-# CI: image push 용도 celery, celery-beat는
-# 로컬 테스트시 용량이 커 보통 끄고 테스트하기 때문에 따로 만들었습니다.
 services:     # 컨테이너 지정
 
   web:
@@ -8,10 +6,6 @@ services:     # 컨테이너 지정
     build:
       context: .  # . 은 디폴트 -> 프로젝트 내의 "Dockerfile"이라는 이름을 알아서 찾아 빌드해줌
       dockerfile: Dockerfile.prod  # 배포용 Dockerfile 지정
-    environment:
-      DJANGO_SETTINGS_MODULE: golbang.settings
-      REDIS_URL: redis://redis:6379/0  # Redis URL 환경 변수 설정
-      REDIS_HOST: redis
     restart: always
     ports:
       - "8000:8000"
@@ -23,18 +17,19 @@ services:     # 컨테이너 지정
     container_name: redis
     image: redis:latest
     restart: always
-    ports: # 포트포워딩 - 로컬의 호스트가 6379 포트를 사용 중일 수 있으므로 6379 포트를 도커 컨테이너의 6379 포트로 포워딩해줌
+    ports:
       - "6379:6379"
+    environment:
+      - REDIS_PASSWORD=${MYSQL_DB_PASSWORD}
+    command: redis-server --requirepass ${MYSQL_DB_PASSWORD}
+    volumes:
+      - redisdata:/data
 
   celery:   # celery 작업자
     container_name: celery
     image: "${DOCKER_USERNAME}/celery:${VERSION}"
     build: .
     command: celery -A golbang worker -l info
-    environment:
-      DJANGO_SETTINGS_MODULE: golbang.settings
-      REDIS_URL: redis://redis:6380/0
-      REDIS_HOST: redis
     env_file:
       - .env
 
@@ -43,9 +38,5 @@ services:     # 컨테이너 지정
     image: "${DOCKER_USERNAME}/celery-beat:${VERSION}"
     build: .
     command: celery -A golbang beat -l info
-    environment:
-      DJANGO_SETTINGS_MODULE: golbang.settings
-      REDIS_URL: redis://redis:6380/0
-      REDIS_HOST: redis
     env_file:
       - .env

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -3,10 +3,6 @@ services:     # 컨테이너 지정
   web:
     container_name: web
     image: "${DOCKER_USERNAME}/web:${VERSION}"  # CI에서 빌드할 이미지 이름
-    environment:
-      DJANGO_SETTINGS_MODULE: golbang.settings
-      REDIS_URL: redis://redis:6379/0  # Redis URL 환경 변수 설정
-      REDIS_HOST: redis
     restart: always
     ports:
       - "8000:8000"
@@ -30,10 +26,6 @@ services:     # 컨테이너 지정
     container_name: celery
     image: "${DOCKER_USERNAME}/celery:${VERSION}"
     command: celery -A golbang worker -l info
-    environment:
-      DJANGO_SETTINGS_MODULE: golbang.settings
-      REDIS_URL: redis://redis:6380/0
-      REDIS_HOST: redis
     env_file:
       - .env
 
@@ -41,10 +33,6 @@ services:     # 컨테이너 지정
     container_name: celery-beat
     image: "${DOCKER_USERNAME}/celery-beat:${VERSION}"
     command: celery -A golbang beat -l info
-    environment:
-      DJANGO_SETTINGS_MODULE: golbang.settings
-      REDIS_URL: redis://redis:6380/0
-      REDIS_HOST: redis
     env_file:
       - .env
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,10 +5,6 @@ services:     # 컨테이너 지정
   web:
     container_name: web
     build: .  # . 은 디폴트 -> 프로젝트 내의 "Dockerfile"이라는 이름을 알아서 찾아 빌드해줌
-    environment:
-      DJANGO_SETTINGS_MODULE: golbang.settings
-      REDIS_URL: redis://redis:6379/0  # Redis URL 환경 변수 설정
-      REDIS_HOST: redis
     restart: always
     volumes:  # 파일 시스템 정의
       - .:/app
@@ -37,36 +33,31 @@ services:     # 컨테이너 지정
     container_name: redis
     image: redis:latest
     restart: always
-    ports: # 포트포워딩 - 로컬의 호스트가 6379 포트를 사용 중일 수 있으므로 6379 포트를 도커 컨테이너의 6379 포트로 포워딩해줌
-      - "6380:6379"
-    volumes: # 파일 시스템 정의
+    ports:
+      - "6379:6379"
+    environment:
+      - REDIS_PASSWORD=${MYSQL_DB_PASSWORD}
+    command: redis-server --requirepass ${MYSQL_DB_PASSWORD}
+    volumes:
       - redisdata:/data
 
   celery:   # celery 작업자
     container_name: celery
     build: .
     command: celery -A golbang worker -l info
-    environment:
-      DJANGO_SETTINGS_MODULE: golbang.settings
-      REDIS_URL: redis://redis:6380/0
-      REDIS_HOST: redis
     volumes:
       - .:/app
     env_file:
       - .env
 
-#  celery-beat:   # 주기적으로 업데이트
-#    container_name: celery-beat
-#    build: .
-#    command: celery -A golbang beat -l info
-#    environment:
-#      DJANGO_SETTINGS_MODULE: golbang.settings
-#      REDIS_URL: redis://redis:6380/0
-#      REDIS_HOST: redis
-#    volumes:
-#      - .:/app
-#    env_file:
-#      - .env
+  celery-beat:   # 주기적으로 업데이트
+    container_name: celery-beat
+    build: .
+    command: celery -A golbang beat -l info
+    volumes:
+      - .:/app
+    env_file:
+      - .env
 
 volumes:
   dbdata:

--- a/golbang/settings.py
+++ b/golbang/settings.py
@@ -138,19 +138,21 @@ INSTALLED_APPS = [
 ]
 # 웹 소켓을 위한 비동기 애플리케이션
 ASGI_APPLICATION = 'golbang.asgi.application'
+REDIS_PASSWORD = os.environ.get('MYSQL_DB_PASSWORD','')
 
 CHANNEL_LAYERS = {
     'default': {
         'BACKEND': 'channels_redis.core.RedisChannelLayer',
         'CONFIG': {
             "hosts": [(os.environ.get('REDIS_HOST', 'localhost'), 6379)],
+            "password": REDIS_PASSWORD,
         },
     },
 }
 
 # Celery
-CELERY_BROKER_URL = 'redis://redis:6379/0'
-CELERY_RESULT_BACKEND = 'redis://redis:6379/0'
+CELERY_BROKER_URL = f'redis://:{REDIS_PASSWORD}@redis:6379/0'
+CELERY_RESULT_BACKEND = f'redis://:{REDIS_PASSWORD}@redis:6379/0'
 CELERY_ACCEPT_CONTENT = ['application/json']
 CELERY_RESULT_SERIALIZER = 'json'
 CELERY_TASK_SERIALIZER = 'json'


### PR DESCRIPTION
### 🐛 버그 수정
1. 웹소켓 돋작 안함
2. celery, celery-beat 모두 동작 안함

- 원인
단순히 레디스에 비밀번호를 추가하는 작업이라 생각해 따로 로컬에서 테스트를 안했는데...
이 비밀번호 추가로 레디스와 서버, celery가 모두 연결이 끊겼더라구요.

앞으로 주의하도록 하겠습니다 ㅎㅎ..

- 해결
프론트 테스트는 아직 안했는데, 테스트 서버에 배포되면 진행할 예정입니다.
장고 세팅 파일에 레디스 비밀번호를 추가해주었습니다.

### 리팩토링
저희 장고는 설정파일이 `.env` 파일에서 직접 가져다 쓰는 형태라
docker-compose 파일의 환경변수를 안쓰고 있더라구요. 그래서, 안쓰는 삭제하였씁니다
