### PR TITLE
fix: ci에서 볼륨 제거

### DIFF
--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -22,8 +22,6 @@ services:     # 컨테이너 지정
     environment:
       - REDIS_PASSWORD=${MYSQL_DB_PASSWORD}
     command: redis-server --requirepass ${MYSQL_DB_PASSWORD}
-    volumes:
-      - redisdata:/data
 
   celery:   # celery 작업자
     container_name: celery


### PR DESCRIPTION
### 🐛 버그 수정
CI 스크립트에서는 볼륨 설정을 안해서 제거해야하는데, 
복사 과정에서 redis 볼륨이 추가되어 다시 삭제 하였습니다
