### PR TITLE
hotfix: redis_client에 password 추가

### DIFF
--- a/participants/stroke/redis_interface.py
+++ b/participants/stroke/redis_interface.py
@@ -11,11 +11,17 @@ import logging
 from asgiref.sync import sync_to_async
 import redis
 
+from golbang import settings
 from participants.models import Participant
 from participants.stroke.data_class import EventData, ParticipantResponseData
 
 # Redis 클라이언트 설정
-redis_client = redis.StrictRedis(host='redis', port=6379, db=0)
+redis_client = redis.StrictRedis(
+    host='redis', 
+    port=6379, 
+    db=0, 
+    password=settings.REDIS_PASSWORD
+)
 
 
 class RedisInterface:


### PR DESCRIPTION
### 🐛 버그 수정
celery가 꺼지던 문제는 해결됐으나
웹소켓 통신이 안되는 문제는 여전하여 RediInterface에서 사용하는 redis_client에 비밀번호를 추가하였습니다.
