### PR TITLE
hotfix: CHANNEL_LAYER에 레디스 비밀번호 입력 방식 변경

### DIFF
--- a/golbang/settings.py
+++ b/golbang/settings.py
@@ -144,8 +144,7 @@ CHANNEL_LAYERS = {
     'default': {
         'BACKEND': 'channels_redis.core.RedisChannelLayer',
         'CONFIG': {
-            "hosts": [(os.environ.get('REDIS_HOST', 'localhost'), 6379)],
-            "password": REDIS_PASSWORD,
+            "hosts":[f"redis://:{os.environ.get('MYSQL_DB_PASSWORD')}@redis:6379/0"],
         },
     },
 }


### PR DESCRIPTION
### 🐛 버그 수정
```
Exception inside application: RedisChannelLayer.__init__() got an unexpected keyword argument 'password'
```
에러 메시지에서 password를 인자로 넣지 말라 돼있어서, url에 입력하는 형태로 바꾸었습니다.