### PR TITLE
fix: 참가자 상태 무관하게 모두 반환하도록 변경

### DIFF
--- a/participants/stroke/mysql_interface.py
+++ b/participants/stroke/mysql_interface.py
@@ -47,10 +47,7 @@ class MySQLInterface:
     @database_sync_to_async
     def get_event_participants(self, event_id):
         # 특정 이벤트에 참여한 모든 참가자를 반환
-        return list(Participant.objects.filter(
-            Q(status_type=Participant.StatusType.PARTY) | Q(status_type=Participant.StatusType.ACCEPT),
-            event_id=event_id
-        ).select_related('club_member__user'))
+        return list(Participant.objects.filter(event_id=event_id).select_related('club_member__user'))
 
     @database_sync_to_async
     def get_and_check_participant(self, participant_id, user):


### PR DESCRIPTION
### 🐛 버그 수정
이 코드를 추가했던 이유가 스코어카드나 랭킹 페이지에서 불참자들 안보이게 하려고 한건데,
막상 웹소켓 코드를 보니 점수 입력 전까지는 참가자들 명단은 프론트에서 관리하더라구요.

오히려 이게 에러 원인인거 같기도 하고, 불필요해져서 되돌렸습니다.