### PR TITLE
Hotfix: release 전용 러너 label 설정

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -92,7 +92,7 @@ jobs:
 
   deploy-release:
     if: github.ref == 'refs/heads/release'  # release 브랜치에서만 실행  
-    runs-on: self-hosted  #TODO:  release 전용 러너 수정하기
+    runs-on: release
     needs: build
     steps:
       - name: Deploy for release branch


### PR DESCRIPTION
Release 전용 러널 라벨명을 설정했습니다.
기존에 `self-hosted`에서 `release`로 명시했습니다.