### PR TITLE
Hotfix: PROD 용 S3와 RDS 생성 후 github secret 변수명 변경 적용

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,24 +25,23 @@ jobs:
 
       - name: Create .env file from SERVER_ENV_FILE secret
         run: |
-          # 공통.env 파일 생성
-          echo "${{ secrets.SERVER_ENV_FILE }}" | sed 's/\r$//' > .env
+          # 브랜치별별 기본 .env 파일 생성
+          BRANCH_NAME=${{ github.ref_name }}
+          if [ "$BRANCH_NAME" == "main" ]; then
+            echo "${{ secrets.SERVER_ENV_STAG_FILE }}" | sed 's/\r$//' > .env
+          elif [ "$BRANCH_NAME" == "release" ]; then
+            echo "${{ secrets.SERVER_ENV_PROD_FILE }}" | sed 's/\r$//' > .env
+          else
+            echo "Unknown branch: $BRANCH_NAME"
+            exit 1
+          fi
+          
           # SECRET_KEY 추가
           echo "SECRET_KEY=${{ secrets.SECRET_KEY }}" >> .env
           echo "VERSION=${{ github.sha }}" >> .env
           echo "DOCKER_USERNAME=${{ secrets.DOCKER_USERNAME }}" >> .env
           echo "DOCKER_PASSWORD=${{ secrets.DOCKER_PASSWORD }}" >> .env
           
-          # 브랜치별 환경 변수 추가
-          BRANCH_NAME=${{ github.ref_name }}
-          if [ "$BRANCH_NAME" == "main" ]; then
-            echo "AWS_HOST_IP=${{ secrets.AWS_HOST_IP_STAG }}" >> .env
-          elif [ "$BRANCH_NAME" == "release" ]; then
-            echo "AWS_HOST_IP=${{ secrets.AWS_HOST_IP_PROD }}" >> .env
-          else
-            echo "Unknown branch: $BRANCH_NAME"
-            exit 1
-          fi
 
       - name: Upload Docker Compose and list of variables as artifacts
         uses: actions/upload-artifact@v4
@@ -82,12 +81,11 @@ jobs:
 
       - name: Create .env file from SERVER_ENV_FILE secret
         run: |
-          echo "${{ secrets.SERVER_ENV_FILE }}" | sed 's/\r$//' > ${{ github.workspace }}/.env
+          echo "${{ secrets.SERVER_ENV_STAG_FILE }}" | sed 's/\r$//' > ${{ github.workspace }}/.env
           echo "SECRET_KEY=${{ secrets.SECRET_KEY }}" >> ${{ github.workspace }}/.env
           echo "VERSION=${{ github.sha }}" >> .env
           echo "DOCKER_USERNAME=${{ secrets.DOCKER_USERNAME }}" >> .env
           echo "DOCKER_PASSWORD=${{ secrets.DOCKER_PASSWORD}}" >> .env
-          echo "AWS_HOST_IP=${{ secrets.AWS_HOST_IP_STAG }}" >> .env 
 
       - name: Download deployment artifacts
         uses: actions/download-artifact@v4
@@ -103,6 +101,8 @@ jobs:
           sudo docker-compose --env-file .env -f docker-compose.prod.yml up -d
 
   deploy-release:
+    # TODO: deploy-dev와 거의 대부분 비슷한 코드. 코드 최적화 필요
+
     if: github.ref == 'refs/heads/release'  # release 브랜치에서만 실행  
     runs-on: release
     needs: build
@@ -124,12 +124,11 @@ jobs:
 
       - name: Create .env file from SERVER_ENV_FILE secret
         run: |
-          echo "${{ secrets.SERVER_ENV_FILE }}" | sed 's/\r$//' > ${{ github.workspace }}/.env
+          echo "${{ secrets.SERVER_ENV_PROD_FILE }}" | sed 's/\r$//' > ${{ github.workspace }}/.env
           echo "SECRET_KEY=${{ secrets.SECRET_KEY }}" >> ${{ github.workspace }}/.env
           echo "VERSION=${{ github.sha }}" >> .env
           echo "DOCKER_USERNAME=${{ secrets.DOCKER_USERNAME }}" >> .env
           echo "DOCKER_PASSWORD=${{ secrets.DOCKER_PASSWORD}}" >> .env
-          echo "AWS_HOST_IP=${{ secrets.AWS_HOST_IP_STAG }}" >> .env 
 
       - name: Download deployment artifacts
         uses: actions/download-artifact@v4


### PR DESCRIPTION
PROD 환경을 위한 **S3와 RDS**를 생성하고, 이를 기반으로 새로운 환경 설정을 업데이트하였습니다.

RDS 생성 시 서브넷이 `1c`에만 생성되어 있어 추가로 `1a`까지 설정을 완료하였습니다. (`1a`와 `1c` 모두 설정되어야만  RDS가 생성된다고 명시되어 있어 추가했습니다.) 또한, Private 서브넷이 라우팅 테이블과 별도로 연결되어 있어야 했으나 해당 설정이 누락되어 있음을 발견하고, 관련 내용을 참고하여 수정하였습니다.
   - 참고 사이트:
     - [[왕초보 탈출 AWS 매뉴얼(1)] VPC & Public Subnet 생성](https://minjii-ya.tistory.com/32)
     - [[왕초보 탈출 AWS 매뉴얼(2)] Private Subnet 생성](https://minjii-ya.tistory.com/33?category=946161)

- `main.yaml`에는 브랜치에 따라 깃허브 시크릿을 가져오는 부분만 다르게 설정하였으며, 필요한 깃허브 시크릿을 새로 추가하였습니다.
- 현재 `deploy-dev`와 `deploy-release`에는 반복되는 코드가 존재하며, 추후 코드 최적화가 필요할 것으로 보입니다.- 
- `env.stag`와 `env.prod`는 디코 아카이브에 새로 업데이트하였으니 참고 부탁드립니다.
