### PR TITLE
feat&refactor: ALB 리스너 상태 API 생성 및 AWS_IP를 서브 도메인으로 교체

### DIFF
--- a/golbang/settings.py
+++ b/golbang/settings.py
@@ -43,7 +43,7 @@ MAIN_DOMAIN = env('MAIN_DOMAIN')
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True # 프로덕션 환경에서는 False로 해야 함
 
-ALLOWED_HOSTS = ['localhost', '127.0.0.1', '10.0.2.2', os.getenv("AWS_HOST_IP")]
+ALLOWED_HOSTS = ['localhost', '127.0.0.1', '10.0.2.2','.golf-bang.store']
 
 # FCM
 cred_path = os.path.join(BASE_DIR, "serviceAccountKey.json")

--- a/golbang/urls.py
+++ b/golbang/urls.py
@@ -13,6 +13,7 @@ from django.contrib import admin
 from django.urls import include, path, re_path
 from drf_yasg.views import get_schema_view
 from drf_yasg import openapi
+from golbang.views import health_check
 from rest_framework.permissions import AllowAny
 
 schema_view_v1 = get_schema_view(
@@ -29,6 +30,7 @@ schema_view_v1 = get_schema_view(
 )
 
 urlpatterns = [
+    path('health/', health_check, name='health_check'),
     path('admin/', admin.site.urls),  # admin 페이지
     path('api/v1/users/', include('accounts.urls')),    # accounts 앱의 URL
     path('api/v1/clubs/', include('clubs.urls')),       # clubs 앱의 URL

--- a/golbang/views.py
+++ b/golbang/views.py
@@ -1,0 +1,5 @@
+# golf-bang/views.py
+from django.http import JsonResponse
+
+def health_check(request):
+    return JsonResponse({"status": "ok"}, status=200)


### PR DESCRIPTION
### ✨기능 추가
[feat: 상태관리API 생성](https://github.com/iNESlab/Golbang_BE/commit/bfc6fe2f8a912153a94c206dc3a37d376f3a66f4)
<img width="422" alt="image" src="https://github.com/user-attachments/assets/de5eaf19-5b48-4179-a60d-3a771571d0f7" />
AWS 상태 검사를 위해 API 만들었습니다

### ♻ 코드 리팩토링
[refactor: 서버 ip 도메인 주소로 변경](https://github.com/iNESlab/Golbang_BE/commit/3bd7c3478a2455f01f17f1e862c71c96b2f60a48)

- 서브 도메인으로 `dev.golf-bang`, `us.golf-bang` 접속시 Allowed Error가 떠서
- AllowedHost에 서`.golf-bang`(와일드 카드 패턴)를  추가했습니다. 
