### PR TITLE
hotfix: http -> https 리다이렉트 해제

### DIFF
--- a/golbang/settings.py
+++ b/golbang/settings.py
@@ -226,8 +226,6 @@ CORS_ORIGIN_WHITELIST = [
 
 CORS_ALLOW_CREDENTIALS = True
 
-SECURE_SSL_REDIRECT = True  # HTTP -> HTTPS 리다이렉트
-
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',


### PR DESCRIPTION
실제 배포환경에서는 ALB나 NGINX를 이용해서
외부 https를 Http로 바꿔주는게 좋다고 하네용..
그래서, 장고는 http만 쓰면 된다네요 