### PR TITLE
fix: CSRF 리다이렉트된 경우 추가

### DIFF
--- a/golbang/settings.py
+++ b/golbang/settings.py
@@ -209,6 +209,8 @@ SIMPLE_JWT = {
 CSRF_TRUSTED_ORIGINS = [
     'https://us.golf-bang.store',
     'https://dev.golf-bang.store',
+    'https://us.golf-bang.store:8000',
+    'https://dev.golf-bang.store:8000',
     'http://10.0.2.2:8080',  # Flutter 개발 환경
 ]
 


### PR DESCRIPTION
### 🐛 버그 수정
<img width="630" alt="image" src="https://github.com/user-attachments/assets/f1ec9fd1-0922-4061-951e-277ce0b68745" />

GPT가 `ALB가 리다이렉트 후 사용하는 도메인` 추가해야한다 해서 추가합니다
