### PR TITLE
hotfix: 웹소켓 통신시, Allowed 에러발생하여 ALB 도메인 추가

### DIFF
--- a/golbang/settings.py
+++ b/golbang/settings.py
@@ -43,7 +43,13 @@ MAIN_DOMAIN = env('MAIN_DOMAIN')
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True # 프로덕션 환경에서는 False로 해야 함
 
-ALLOWED_HOSTS = ['localhost', '127.0.0.1', '10.0.2.2','.golf-bang.store', '10.0.1.27']
+ALLOWED_HOSTS = [
+    'localhost', 
+    '10.0.2.2',
+    '.golf-bang.store', 
+    '10.0.1.27', 
+    env('ALB_DOMAIN')# ALB 도메인
+] 
 
 # FCM
 cred_path = os.path.join(BASE_DIR, "serviceAccountKey.json")


### PR DESCRIPTION
### 🐛 버그 수정
```
ec2-user@ip-10-0-1-27 ~]$ docker logs --tail 100 web
  File "/usr/local/lib/python3.12/site-packages/django/core/handlers/exception.py", line 42, in inner
    response = await get_response(request)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/django/core/handlers/base.py", line 235, in _get_response_async
    callback, callback_args, callback_kwargs = self.resolve_request(request)
                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/django/core/handlers/base.py", line 313, in resolve_request
    resolver_match = resolver.resolve(request.path_info)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/django/urls/resolvers.py", line 702, in resolve
    raise Resolver404({"tried": tried, "path": new_path})
django.urls.exceptions.Resolver404: {'tried': [[<URLPattern 'health/' [name='health_check']>], [<URLResolver <URLPattern list> (admin:admin) 'admin/'>], [<URLResolver <module 'accounts.urls' from '/app/accounts/urls.py'> (None:None) 'api/v1/users/'>], [<URLResolver <module 'clubs.urls' from '/app/clubs/urls.py'> (None:None) 'api/v1/clubs/'>], [<URLResolver <module 'events.urls' from '/app/events/urls.py'> (None:None) 'api/v1/events/'>], [<URLResolver <module 'participants.urls' from '/app/participants/urls.py'> (None:None) 'api/v1/participants/'>], [<URLResolver <module 'golf_data.urls' from '/app/golf_data/urls.py'> (None:None) 'api/v1/golfcourses/'>], [<URLResolver <module 'notifications.urls' from '/app/notifications/urls.py'> (None:None) 'api/v1/notifications/'>], [<URLResolver <module 'feedbacks.urls' from '/app/feedbacks/urls.py'> (None:None) 'api/v1/feedbacks/'>], [<URLResolver <module 'drf_social_oauth2.urls' from '/usr/local/lib/python3.12/site-packages/drf_social_oauth2/urls.py'> (drf:drf) 'auth/'>], [<URLPattern '^swagger(?P<format>\.json|\.yaml)$' [name='schema-json']>], [<URLPattern '^swagger/$' [name='schema-swagger-ui']>], [<URLPattern '^redoc/$' [name='schema-redoc']>]], 'path': ''}

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.12/site-packages/asgiref/sync.py", line 518, in thread_handler
    raise exc_info[1]
  File "/usr/local/lib/python3.12/site-packages/django/core/handlers/exception.py", line 42, in inner
    response = await get_response(request)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/corsheaders/middleware.py", line 67, in __acall__
    response = await result
               ^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/django/core/handlers/exception.py", line 44, in inner
    response = await sync_to_async(
               ^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/asgiref/sync.py", line 468, in __call__
    ret = await asyncio.shield(exec_coro)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/asgiref/sync.py", line 520, in thread_handler
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/django/core/handlers/exception.py", line 66, in response_for_exception
    response = debug.technical_404_response(request, exc)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/django/views/debug.py", line 634, in technical_404_response
    return HttpResponseNotFound(t.render(c))
                                ^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/django/template/base.py", line 175, in render
    return self._render(context)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/django/template/base.py", line 167, in _render
    return self.nodelist.render(context)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/django/template/base.py", line 1005, in render
    return SafeString("".join([node.render_annotated(context) for node in self]))
                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/django/template/base.py", line 966, in render_annotated
    return self.render(context)
           ^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/django/template/base.py", line 1064, in render
    output = self.filter_expression.resolve(context)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/django/template/base.py", line 715, in resolve
    obj = self.var.resolve(context)
          ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/django/template/base.py", line 847, in resolve
    value = self._resolve_lookup(context)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/django/template/base.py", line 914, in _resolve_lookup
    current = current()
              ^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/django/http/request.py", line 234, in build_absolute_uri
    location = self._current_scheme_host + location
               ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/django/utils/functional.py", line 57, in __get__
    res = instance.__dict__[self.name] = self.func(instance)
                                         ^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/django/http/request.py", line 244, in _current_scheme_host
    return "{}://{}".format(self.scheme, self.get_host())
                                         ^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/django/http/request.py", line 150, in get_host
    raise DisallowedHost(msg)
django.core.exceptions.DisallowedHost: Invalid HTTP_HOST header: '3.34.171.55:8000'. You may need to add '3.34.171.55' to ALLOWED_HOSTS.
Bad Request: /
```
- ALB IP로 추정되는 Allowed Error 발생하여 도메인 추가
- 환경변수 ALB_DOMAIN 업데이트
