### PR TITLE
Release: wss 업그레이드 배포

### DIFF
--- a/golbang/settings.py
+++ b/golbang/settings.py
@@ -226,8 +226,6 @@ CORS_ORIGIN_WHITELIST = [
 
 CORS_ALLOW_CREDENTIALS = True
 
-SECURE_SSL_REDIRECT = True  # HTTP -> HTTPS 리다이렉트
-
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',

--- a/golbang/settings.py
+++ b/golbang/settings.py
@@ -209,6 +209,8 @@ SIMPLE_JWT = {
 CSRF_TRUSTED_ORIGINS = [
     'https://us.golf-bang.store',
     'https://dev.golf-bang.store',
+    'https://us.golf-bang.store:8000',
+    'https://dev.golf-bang.store:8000',
     'http://10.0.2.2:8080',  # Flutter 개발 환경
 ]
 

--- a/golbang/settings.py
+++ b/golbang/settings.py
@@ -43,7 +43,13 @@ MAIN_DOMAIN = env('MAIN_DOMAIN')
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True # 프로덕션 환경에서는 False로 해야 함
 
-ALLOWED_HOSTS = ['localhost', '127.0.0.1', '10.0.2.2','.golf-bang.store', '10.0.1.27']
+ALLOWED_HOSTS = [
+    'localhost', 
+    '10.0.2.2',
+    '.golf-bang.store', 
+    '10.0.1.27', 
+    env('ALB_DOMAIN')# ALB 도메인
+] 
 
 # FCM
 cred_path = os.path.join(BASE_DIR, "serviceAccountKey.json")

--- a/participants/routing.py
+++ b/participants/routing.py
@@ -5,6 +5,6 @@ from django.urls import path
 from participants.stroke import stroke_event_consumers, stroke_group_consumers
 
 websocket_urlpatterns = [
-    path('ws/participants/<int:participant_id>/event/stroke', stroke_event_consumers.EventParticipantConsumer.as_asgi()),
-    path('ws/participants/<int:participant_id>/group/stroke', stroke_group_consumers.GroupParticipantConsumer.as_asgi()),
+    path('wss/participants/<int:participant_id>/event/stroke', stroke_event_consumers.EventParticipantConsumer.as_asgi()),
+    path('wss/participants/<int:participant_id>/group/stroke', stroke_group_consumers.GroupParticipantConsumer.as_asgi()),
 ]


### PR DESCRIPTION
[fix: 웹소켓 통신시, Allowed 에러발생하여 ALB 도메인 추가](https://github.com/iNESlab/Golbang_BE/commit/99bbd9035b5a06800d237b5d3ab173d863617f64)

이건 알고보니 사실 안해도 되는 작업이더라구요. 그래도 혹시 모르니 그대로 두겠습니다. (ALB 도메인이 쓰일 때가 올수도...)

### ✨기능 추가
이제 ws에서 보안을 강화한 wss프로토콜 동작합니다
- https는 aws ALB를 통해 해결
- wss는 https가 되면, 서버에서 경로만 수정하는 것으로 해결됩니다.

### ALB
1. 프론트에서 https, 8000포트로 요청
2. ALB가 https를 http로 변환하여 EC2 8000포트에 전달
3. 서버는 http로 응답받고 다시 ALB에 http로 응답
4. ALB는 https로 프론트에 응답
> 구글에서 나오는 것들은 http -> https로 바꿔주는 내용에만 치중돼있어서...
서버 포트 이런걸 고려 안하니 나중에 보시게 되면 참고 하십쇼오오

기타) 프론트에서 http, 80포트로 요청시 https, 8000포트로 리아디이렉트 되게끔 설정하였습니다 

