### PR TITLE
hotfix: 알림 redis client에도 redis 비밀번호 전달

### DIFF
--- a/notifications/redis_interface.py
+++ b/notifications/redis_interface.py
@@ -1,10 +1,16 @@
+from golbang import settings
 import redis
 import json
 from asgiref.sync import sync_to_async
 from datetime import datetime
 
 # Redis 클라이언트 초기화
-redis_client = redis.StrictRedis(host='redis', port=6379, db=0)
+redis_client = redis_client = redis.StrictRedis(
+    host='redis', 
+    port=6379, 
+    db=0, 
+    password=settings.REDIS_PASSWORD
+)
 
 
 class NotificationRedisInterface:


### PR DESCRIPTION
### 🐛 버그 수정
알림이 오는데, 알림 페이지에 안뜨는 문제 발생

원인 : 이전에, redis 비밀번호를 추가하면서 스코어 카드 redis client는 비밀번호를 받도록 수정하였는데,
알림은 조치를 하지 않았음.

수정 : redis client 수정
```
redis_client = redis.StrictRedis(
    host='redis', 
    port=6379, 
    db=0, 
    password=settings.REDIS_PASSWORD
)
```
