### PR TITLE
hotfix: ClubMember 시리얼라이저 User 필드 추가

### DIFF
--- a/clubs/serializers.py
+++ b/clubs/serializers.py
@@ -34,18 +34,14 @@ class ClubMemberSerializer(serializers.ModelSerializer):
     ClubMember 모델을 직렬화하는 클래스
     클럽 내의 멤버의 멤버아이디, 이름, 역할에 대한 정보가 담김
     '''
+    user= UserSerializer(read_only=True)
     member_id = serializers.PrimaryKeyRelatedField(source='id', read_only=True)
-    name = serializers.CharField(source='user.name')
-    profile_image = serializers.SerializerMethodField(read_only=True)
     is_current_user_admin = serializers.SerializerMethodField()  # 현재 사용자가 관리자인지 여부를 반환
 
     class Meta:
         model = ClubMember
-        fields = ('member_id', 'name', 'role', 'profile_image', 'is_current_user_admin')
+        fields = ('user','member_id', 'role', 'is_current_user_admin')
 
-    def get_profile_image(self, obj):
-        profile_image = obj.user.profile_image
-        return profile_image.url if profile_image else None
 
     def get_is_current_user_admin(self, obj):
         '''


### PR DESCRIPTION
## 📝작업 내용
> 정리한 노션이 있다면 추가해주세요.
### 중범선배 요청s 
초대시, 기존 회원을 여부를 확인하기 위해, 회원 조회 API에 유저 id추가하기

### 방법 
기존에, ClubMemberSerializer에서
name, profile_image 등 User정보를 이미 쓰고 있어서, 
UserSerializer로 통합해서 사용함

## 📌보완해야 할 점 (선택)

지금, Club쪽에서 안쓰는 시리얼라이즈도 많이 있고,
UserSerializer가 생성돼있는데, UserSerializer를 안사용하고 user로 모든 필드를 가져오는 시리얼라이저들이 보입니다.

이런 부분은 UserSerializer로 간소화하면 좋을 것 같아요.

추가로, API 응답할 때, 
예전에 컨벤션으로 클럽 id면 club_id, 회원이면 member_id
이렇게 약속했던거 같은데, id만 존재하는 경우도 보입니다.
ex) club 조회 API에서 club_id가 그냥 id로 응답되고 있어요.
(user_id는 쩔수지만...)
이런 response에 대한 통일을 리팩토링때 다시 이야기 나누고 진행해야될 것 같습니다.

프론트 리팩토링은 그 후..?