### PR TITLE
Feat: 이미지 업로드 최적화 - WebP 변환 및 용량 압축 적용

### DIFF
--- a/accounts/views.py
+++ b/accounts/views.py
@@ -29,6 +29,7 @@ from django.contrib.auth import get_user_model
 from django.shortcuts import redirect, render
 from django.http import QueryDict
 
+from utils.compress_image import compress_image
 from utils.delete_s3_image import delete_s3_file
 
 User = get_user_model()
@@ -178,7 +179,7 @@ class UserInfoViewSet(viewsets.ModelViewSet):
                 print(f"image_key: {instance.profile_image}")
 
                 # S3 이미지 삭제 함수 호출
-                if delete_s3_file(instance.profile_image):
+                if delete_s3_file("accounts", instance.profile_image):
                     instance.profile_image = None  # 프로필 이미지를 None으로 설정
                     instance.save()
 
@@ -192,6 +193,7 @@ class UserInfoViewSet(viewsets.ModelViewSet):
 
         try:
             serializer = self.get_serializer(instance, data=request.data, partial=True)
+
             if not serializer.is_valid():
                 print(f"Validation errors: {serializer.errors}")
                 return Response({

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -192,6 +192,12 @@ class UserInfoViewSet(viewsets.ModelViewSet):
                 request.data['profile_image'] = None
 
         try:
+            # 이미지 압축 적용
+            image = request.FILES.get('profile_image', None)
+            if image:
+                compressed_image = compress_image(image, output_format="WEBP")
+                request.data['profile_image'] = compressed_image
+
             serializer = self.get_serializer(instance, data=request.data, partial=True)
 
             if not serializer.is_valid():

--- a/clubs/views/club_common.py
+++ b/clubs/views/club_common.py
@@ -17,7 +17,7 @@ from rest_framework.permissions import IsAuthenticated, BasePermission
 from django.http import Http404, QueryDict
 import logging
 
-
+from utils.compress_image import compress_image
 from ..models import Club, ClubMember, User
 from ..serializers import (ClubSerializer, ClubCreateUpdateSerializer, ClubMemberAddSerializer, ClubAdminAddSerializer,
                            ClubMemberSerializer) # TODO: 안 쓰는 건 제거
@@ -83,6 +83,7 @@ class ClubViewSet(viewsets.ModelViewSet):
     '''
     모임 공통 기능
     '''
+
     def process_request_data(self, request):
         """ 요청 데이터를 적절한 형식으로 변환하여 반환 """
         if isinstance(request.data, QueryDict):
@@ -135,6 +136,12 @@ class ClubViewSet(viewsets.ModelViewSet):
         # members와 admins 리스트를 id로 변경
         data['members'] = members_ids
         data['admins'] = admins_ids
+
+        # 이미지 압축 적용
+        image = request.FILES.get('image', None)
+        if image:
+            compressed_image = compress_image(image, output_format="WEBP")
+            data['image'] = compressed_image  # 압축된 이미지로 데이터 변경
 
         serializer = self.get_serializer(data=data)  # 요청 데이터를 사용해 serializer 초기화
 

--- a/golf_data/admin.py
+++ b/golf_data/admin.py
@@ -23,7 +23,7 @@ class ExcelFileUploadAdmin(admin.ModelAdmin):
         # 기존 파일을 삭제하기 전에 S3 이미지 삭제 함수 호출
         existing_files = ExcelFileUpload.objects.all()
         for existing_file in existing_files:
-            if existing_file.file and delete_s3_file(existing_file.file):
+            if existing_file.file and delete_s3_file("golf_data", existing_file.file):
                 print(f"=====기존 파일이 존재한다면 s3도 삭제!!!!")
                 # S3에서 파일 삭제 성공 시 기존 데이터 삭제
                 existing_file.delete()

--- a/utils/compress_image.py
+++ b/utils/compress_image.py
@@ -1,0 +1,54 @@
+from io import BytesIO
+from PIL import Image
+from django.core.files.base import ContentFile
+import os
+import logging
+
+logger = logging.getLogger(__name__)
+
+def compress_image(image, quality=70, max_size=(800, 800), output_format="WEBP"):
+    """
+    업로드된 이미지를 압축하고 WebP 형식으로 변환하는 함수
+
+    :param image: Django ImageField (원본 이미지)
+    :param quality: 압축 품질 (0~100)
+    :param max_size: 최대 크기 (너비, 높이)
+    :param output_format: 출력할 이미지 포맷 (WEBP, JPEG, PNG 등)
+    :return: 변환된 이미지
+    """
+    if not image:
+        return None
+
+    original_size = image.size  # 원본 파일 크기
+    original_format = image.name.split('.')[-1].upper()  # 원본 확장자 (PNG, JPG 등)
+
+    img = Image.open(image)
+
+    # 투명 배경 유지 여부 체크
+    if img.mode in ("RGBA", "LA"):
+        img = img.convert("RGBA")  # 알파 채널 유지 (투명배경)
+    else:
+        img = img.convert("RGB")  # 다른 형식은 RGB 변환
+
+    # Pillow 10.0 이상 버전 대응: Image.LANCZOS 또는 Image.Resampling.LANCZOS 사용
+    if hasattr(Image, "Resampling"):  # Pillow 10.0 이상
+        resample = Image.Resampling.LANCZOS
+    else:  # Pillow 9.x 이하
+        resample = Image.LANCZOS
+
+    # 이미지 리사이징 (비율 유지)
+    img.thumbnail(max_size, resample)
+
+    # 압축된 이미지 저장
+    img_io = BytesIO()
+    img.save(img_io, format=output_format, quality=quality)
+
+    compressed_image = ContentFile(img_io.getvalue(), name=f"{os.path.splitext(image.name)[0]}.{output_format.lower()}")
+
+    # 디버깅: 변환 후 파일 크기 출력
+    new_size = len(img_io.getvalue())  # 변환 후 파일 크기 (bytes)
+
+    logger.info(f"[IMAGE COMPRESSION] Original: {original_size / 1024:.2f} KB ({original_format}), "
+                f"Compressed: {new_size / 1024:.2f} KB ({output_format})")
+
+    return compressed_image

--- a/utils/delete_s3_image.py
+++ b/utils/delete_s3_image.py
@@ -5,7 +5,8 @@ from django.conf import settings
 
 logger = logging.getLogger(__name__)
 
-def delete_s3_file(image_key):
+
+def delete_s3_file(domain, image_key):
     """
     S3에서 파일을 삭제하는 함수
 
@@ -14,7 +15,7 @@ def delete_s3_file(image_key):
     """
     s3 = boto3.client('s3', region_name='ap-southeast-2')
     bucket_name = settings.AWS_STORAGE_BUCKET_NAME
-    image_key = f"static/{image_key}"
+    image_key = f"static/{domain}/{image_key}"
     try:
         s3.delete_object(Bucket=bucket_name, Key=image_key)
         print(f"S3에서 파일 {image_key} 삭제 완료")


### PR DESCRIPTION
## 📝작업 내용
> 정리한 노션이 있다면 추가해주세요.
- Django에서 이미지 압축 및 WebP 변환 적용하기 (🔥 최적화)
  

### ✨기능 추가
> **1. 이미지 압축 및 WebP 변환 함수 생성**
🔗 [feat(utils):업로드된 이미지를 압축하고 WebP 형식으로 변환하는 함수 생성](https://github.com/iNESlab/Golbang_BE/commit/d0b55ee371194b41518fe35de5561b6d593e3cbd)
- 📍 파일 위치: `utils/compress_image.py`
- 업로드된 이미지를 **`70%`** 압축하여 **`WebP`** 형식으로 변환 (PNG, JPG → WebP)
- 투명 배경 유지 가능 (RGBA 지원)
- Pillow 10.0+ 호환 (`Image.Resampling.LANCZOS` 사용)

> **모임 생성 및 사용자 정보 수정 시 이미지 압축 적용**
🔗[feat: 이미지를 업로드하는 모임 생성, 사용자 정보 수정 view 함수에 compress_image 함수를 적용하여 이미…](https://github.com/iNESlab/Golbang_BE/commit/65324f405d864a626c00523b6f899c0695fa4441)

- 📍 적용한 파일 및 함수: 
   - `clubs/views/club_common.py` → 모임 생성 시 `compress_image` 적용
   - `accounts/views.py` → 사용자 프로필 이미지 수정 시 `compress_image` 적용  
- 변경 내용:  
    - `request.FILES.get('image')` 또는 `request.FILES.get('profile_image')`에서 파일을 가져와 WebP로 변환 후 저장
    - `serializer.save()` 전에 압축된 이미지를 `validated_data`에 반영하여 저장

### 
> [!NOTE]
> **🖼️ 결과 확인**
> ![image](https://github.com/user-attachments/assets/ea8969bb-cff8-44f6-ae5a-e0ddd0a76b1c)
동일한 이미지이지만, WebP 변환이 적용되면서 확장자가 변경됨 (JPG → WEBP)
> ![image](https://github.com/user-attachments/assets/d3cea3d9-7d81-4542-9ca0-35a11a7ab9d4)
> - 변환 전: 14.76KB (JPG)
> - 변환 후: 9.41KB (WEBP)
> => 약 36% 용량 감소! 🎉

### 🐛 버그 수정
> **S3 파일 삭제 시 경로 오류 수정**
🔗 [fix(delete_s3_image): S3에서 파일 삭제 시 경로를 올바르게 수정](https://github.com/iNESlab/Golbang_BE/commit/89da47e585dbc503b2e976454dd13a9c889246ad)
🔗[fix: delete_s3_image 함수에 경로도 함께 넘겨주도록 수정](https://github.com/iNESlab/Golbang_BE/commit/5576124f5df9e1187dbe2cd217615814f8a8a728)

- 골프장 코스 DB를 테스트하면서 S3에 업로드된 파일이 정상적으로 삭제되지 않는 문제를 발견
- 원인: static/ 디렉토리 내 하위 경로를 포함하지 않음
- 해결: S3 파일 삭제 시 경로를 포함하도록 수정


## 📌보완해야 할 점 (선택)
현재 로컬 테스트 완료, 하지만 

- [ ] 서버 배포 후에도 추가적인 테스트 필요


## 💬 리뷰 요구사항(선택)
1. compress_image.py 파일명 및 함수명이 적절한지 피드백 부탁드립니다.
2. 모임 생성 & 프로필 수정에서 이미지 변환 처리 방식에 대한 개선 의견이 있다면 공유해주세요.
