### PR TITLE
feat(event): 이벤트 스코어 카드 조회 시 참석/참석회식 을 선택한 참여자들만 반환되도록 필터링 추가

### DIFF
--- a/events/views/views.py
+++ b/events/views/views.py
@@ -334,7 +334,12 @@ class EventViewSet(viewsets.ModelViewSet):
             return handle_404_not_found('participant', user)
 
         group_type = participant.group_type
-        group_participants = Participant.objects.filter(event=event, group_type=group_type) # 조에 해당하는 참가자들
+
+        group_participants = Participant.objects.filter(
+            event=event,
+            group_type=group_type,
+            status_type__in=[Participant.StatusType.ACCEPT, Participant.StatusType.PARTY]
+        )
 
         # 팀 스코어를 저장할 변수들
         team_a_scores = None


### PR DESCRIPTION
### ✨기능 추가
[feat(event): 이벤트 스코어 카드 조회 시 참석/참석회식 을 선택한 참여자들만 반환되도록 필터링 추가](https://github.com/iNESlab/Golbang_BE/commit/008794c609c39b771640d80d7c48990d379cb2ef)

- status_type을 DENY나 PENDING으로 한 경우에도 스코어 카드 결과 조회에 함께 나오고 있습니다.
- 스코어카드에는 ACCEPT나 PARTY로 표시한 참가자들만 보여야 하기 때문에 이를 필터링하는 코드를 추가하였습니다.

```python
group_participants = Participant.objects.filter(
            event=event,
            group_type=group_type,
            status_type__in=[Participant.StatusType.ACCEPT, Participant.StatusType.PARTY] # 여기
        )
```

### 참고
- 해당 기능이 반영된 후 iOS, Android에서 테스트가 필요합니다.