### PR TITLE
Fix(Event): 이벤트 수정 시 참여자 업데이트 로직 개선(기존 참여자 데이터 부분 업데이트)

### DIFF
--- a/events/tasks.py
+++ b/events/tasks.py
@@ -39,7 +39,7 @@ def send_event_creation_notification(event_id):
         # 토큰 리스트 확인을 위한 로그 출력
         logger.info(f"Retrieved FCM tokens for event creation: {fcm_tokens}")
 
-        message_title = f"{club.name} 모임에서 이벤트가 생성되었습니다."
+        message_title = f"[{club.name}] 모임에서 이벤트가 생성되었습니다."
         message_body = f"이벤트: {event.event_title}\n날짜: {event.start_date_time.strftime('%Y-%m-%d')}\n장소: {event.site}\n참석 여부를 체크해주세요."
 
         # Redis 저장용 알림 데이터 (status는 기본적으로 fail로 설정)
@@ -92,8 +92,8 @@ def send_event_update_notification(event_id):
         logger.info(f"Retrieved FCM tokens for event creation: {fcm_tokens}")
 
 
-        message_title = f"{club.name} 모임에서 이벤트가 수정되었습니다."
-        message_body = f"수정된 이벤트: {event.event_title}\n날짜: {event.start_date_time.strftime('%Y-%m-%d')}\n장소: {event.site}\n다시 참석 여부를 체크해주세요."
+        message_title = f"[{club.name}] 모임에서 이벤트가 수정되었습니다."
+        message_body = f"수정된 이벤트: {event.event_title}\n날짜: {event.start_date_time.strftime('%Y-%m-%d')}\n장소: {event.site}\n"
 
         # Redis 저장용 알림 데이터 (status는 기본적으로 fail로 설정)
         base_notification_data = {
@@ -166,7 +166,7 @@ def send_event_notification_10_seconds_before(event_id):
         club = event.club
         fcm_tokens = get_fcm_tokens_for_club_members(club)
 
-        message_title = f"{club.name} 이벤트가 곧 시작됩니다!"
+        message_title = f"[{club.name}] 이벤트가 곧 시작됩니다!"
         message_body = f"이벤트: {event.event_title}\n10초 후에 시작됩니다. 참석 여부를 확인해주세요."
 
         # Redis 저장용 알림 데이터
@@ -204,13 +204,13 @@ def schedule_event_notifications(event_id):
         now = timezone.now()
 
         # 이틀 전 알림 예약
-        two_days_before = event.start_date_time - timedelta(seconds=5)
+        two_days_before = event.start_date_time - timedelta(days=2)
         if two_days_before > now:
             countdown_until_2_days = (two_days_before - now).total_seconds()
             two_days_task = send_event_notification_2_days_before.apply_async((event_id,), countdown=countdown_until_2_days)
 
         # 1시간 전 알림 예약
-        one_hour_before = event.start_date_time - timedelta(seconds=3)
+        one_hour_before = event.start_date_time - timedelta(hours=1)
         if one_hour_before > now:
             countdown_until_1_hour = (one_hour_before - now).total_seconds()
             one_hour_task = send_event_notification_1_hour_before.apply_async((event_id,), countdown=countdown_until_1_hour)
@@ -244,7 +244,7 @@ def send_event_notification_2_days_before():
     for event in events:
         club = event.club
         fcm_tokens = get_fcm_tokens_for_club_members(club)
-        message_title = f"{club.name} 모임에서 진행하는 {event.event_title} 이벤트가 시작되기 이틀 전입니다."
+        message_title = f"[{club.name}] 모임에서 진행하는 {event.event_title} 이벤트가 시작되기 이틀 전입니다."
         message_body = f"이벤트 상세 정보와 참석 여부를 확인해주세요."
         # Redis 저장용 알림 데이터 (status는 기본적으로 fail로 설정)
         base_notification_data = {
@@ -288,7 +288,7 @@ def send_event_notification_1_hour_before():
     for event in events:
         club = event.club
         fcm_tokens = get_fcm_tokens_for_club_members(club)
-        message_title = f"{club.name} 모임에서 진행하는 {event.event_title} 이벤트가 시작되기 1시간 전입니다."
+        message_title = f"[{club.name}] 모임에서 진행하는 {event.event_title} 이벤트가 시작되기 1시간 전입니다."
         message_body = f"이벤트 상세 정보와 참석 여부를 확인해주세요."
 
         # Redis 저장용 알림 데이터 (status는 기본적으로 fail로 설정)
@@ -333,7 +333,7 @@ def send_event_notification_event_ended():
     for event in events:
         club = event.club
         fcm_tokens = get_fcm_tokens_for_club_members(club)
-        message_title = f"{club.name} 모임에서 진행하는 {event.event_title} 이벤트가 종료되었습니다."
+        message_title = f"[{club.name}] 모임에서 진행하는 {event.event_title} 이벤트가 종료되었습니다."
         message_body = f"이벤트 결과를 확인해주세요. (스코어 점수 수정은 이벤트 종료 2일 후까지만 가능합니다)"
 
         # Redis 저장용 알림 데이터 (status는 기본적으로 fail로 설정)


### PR DESCRIPTION


## ✨기능 추가
### [feat(event): 이벤트 수정 시 참여자 정보 업데이트 로직 개선 - 기존 참여자 데이터를 삭제하지 않고 부분 업데이트…](https://github.com/iNESlab/Golbang_BE/commit/372cea50fc4ecba13888cc346c981add57043819)

- **기존 방식**: 
이벤트 수정 시 기존의 모든 참가자 데이터를 삭제한 후, 새 데이터를 생성하는 방식으로 구현되어 있음
- **문제점**: 
이미 사용자가 변경한 참석 상태(예: ACCEPT, PARTY 등)가 모두 기본값(PENDING)으로 초기화됨
- **개선 이유**:  
삭제 후 재생성하는 방식 보다는 기존 데이터를 비교하고 수정하는 방식이 사용자 경험 및 성능 면에서 유리하기 때문에 이와 같이 진행

- **비교 (from chatGPT)**

|비교 항목 | 새로 생성 (전체 삭제 후 재생성) | 기존 업데이트 (부분 수정) |
|-- | -- | --|
데이터 상태 유지 | 기존 참가자의 상태가 모두 기본값(PENDING)으로 초기화됨(사용자가 변경한 상태가 모두 사라짐)🔴 | 이미 변경된 상태(예: ACCEPT, PARTY 등)가 유지됨(사용자 설정 보존)🟢
코드 복잡성 | 구현이 간단 (모든 참가자를 삭제하고 새 데이터를 생성하는 단순 로직) 🟢 | 기존 데이터를 비교하고 업데이트하는 로직 필요(조금 더 복잡하지만 세밀한 제어 가능)🔴
데이터베이스 부하 | 삭제와 재생성 작업으로 인한 DB 부하 증가🔴 | 변경된 항목만 업데이트하여 불필요한 삭제/생성 작업을 줄임🟢
트랜잭션 안정성 | 대량 삭제 후 재생성 시 트랜잭션 실패 위험 증가 가능🔴 | 필요한 부분만 수정하므로 트랜잭션 안정성이 높음🟢
이력 및 로그 관리 | 기존 데이터가 삭제되어 변경 이력이나 로그 추적이 어려움🔴 | 기존 데이터의 수정 이력이 유지되어 이력 관리가 용이함🟢
사용자 경험 | 참가자의 참석 상태가 모두 초기화되어, 사용자가 다시 상태를 선택해야 함🔴 | 기존 설정이 보존되므로, 불필요하게 참석 여부를 재확인하지 않아도 됨🟢 
>[!NOTE] 
> 요약: 기존 방식은 단순하지만, 사용자 설정이 초기화되는 문제가 있다. 개선된 방식은 기존 데이터를 비교하여 필요한 부분만 수정하기 때문에, 데이터 상태 보존과 DB 효율성면에서 유리하다.

<!-- notionvc: 31739ba5-3372-430c-8a5c-3aeb0170cc88 -->


> [!IMPORTANT]
> **주요 수정 사항: Step 1: 기존 참가자 조회 -> Step 2: 새로 전달된 참가자 데이터 처리(기존 참가자/신규참가자) -> 기존 데이터와 새 데이터 비교 → 포함하지 않은 기존 참가자는 삭제처리**
> - 파일: `events/serializers.py`
> - 클래스: `EventCreateUpdateSerializer`
> - 메서드: `update`

- **Step 1: 기존 참가자 조회:**
    - `instance.participant_set.all()`로 기존의 참가자 데이터를 불러온 후 → `club_member.id`를 기준으로 딕셔너리(`existing_participants`)에 저장
- **Step 2: 새로 전달된 참가자 데이터 처리:**
    - 각 전달된 참가자 데이터에 대해 **필수 필드**인 `event_id`와 `member_id`를 설정한다.
    - 이후 `club_member.id`를 기준으로 기존 데이터와 비교한다.
        - **기존 참가자:**
            - 만약 이미 등록된 참가자라면, 기존 참가자의 상태를 확인한다. →  클라이언트가 `status_type`을 전달하지 않은 경우 기존의 상태를 유지하도록 한다.
        - **신규 참가자:**
            - 기존에 없는 참가자의 경우, 신규 생성한다.
- **Step 3: 기존 데이터와 새 데이터 비교 → 포함하지 않은 기존 참가자는 삭제처리:**
    - 만약 새로 전달된 데이터에 포함되지 않은 기존 참가자가 있다면,  해당 참가자는 제거된 것이므로 삭제한다.

https://github.com/user-attachments/assets/1f1a06b6-9b58-4645-ae22-c19a9582af47

➡️ 새로운 참가자를 추가하여도 정상적으로 수정되며, 기존 참가자들의 참석 여부는 그대로 유지되는 점을 확인하실 수 있습니다. 


## ♻ 코드 리팩토링 
### [feat(notification): 이벤트 수정 시 알림 메시지 수정(참석여부 관련안내 제거)&메시지 내 모임 강조([]사용)](https://github.com/iNESlab/Golbang_BE/commit/0b4b1d6b3398e674b909d9be088219a14f857aa4)
- 이벤트 수정 시 더 이상 참석 여부를 다시 설정할 필요가 없어, 관련 안내 메시지를 제거했습니다.
- 모임명을 명확히 확인할 수 있도록 _대괄호_를 추가하여 `[모임명] 모임에서 이벤트가 {생성/수정}되었습니다. `형식으로 변경했습니다.


---

## 📌보완해야 할 점 (선택)
- 프론트에서 테스트가 필요합니다.
- 프론트엔드에서 [조 생성] 버튼을 누르지 않고도 바로 참가자를 추가/삭제할 수 있도록 개선이 필요합니다.