### PR TITLE
Feat(Club): 모임 관리자의 모임 수정 API 기능 보완(엔드포인트 변경/이미지 변경 기능&관리자 변경 기능 추가)

### DIFF
--- a/clubs/urls.py
+++ b/clubs/urls.py
@@ -13,7 +13,7 @@ from .views.club_statistics import ClubStatisticsViewSet
 
 router = DefaultRouter()
 router.register(r'', ClubViewSet)
-router.register(r'', ClubAdminViewSet, basename='club-admin')
+router.register(r'admin', ClubAdminViewSet, basename='club-admin')
 router.register(r'', ClubMemberViewSet, basename='club-member')
 router.register(r'statistics', ClubStatisticsViewSet, basename='statistics')
 

--- a/clubs/views/club_member.py
+++ b/clubs/views/club_member.py
@@ -15,8 +15,6 @@ from django.http import Http404
 
 from . import ClubViewSet
 from ..models import Club, ClubMember
-from ..serializers import ClubSerializer, ClubCreateUpdateSerializer, ClubMemberAddSerializer, ClubAdminAddSerializer, \
-    ClubMemberSerializer
 from utils.error_handlers import handle_404_not_found, handle_400_bad_request
 
 # class IsMemberOfClub(BasePermission):


### PR DESCRIPTION
## ✨기능 추가
### [rafact(clubs): 모임 관리자의 이벤트 수정 API에 기능 추가 및 보완, 필요없는 코드 제거](https://github.com/iNESlab/Golbang_BE/commit/59199a03b6aa31a474e46daf3b32f993139f8bd3)
- 모임 수정 API가 프론트엔드 **사용자 피드백**에 따라 확장되었습니다.
  - 기존에 단순히 모임의 기본 정보(이름, 설명 등)만 수정하는 것이 아니라, **이미지 수정과 관리자 추가/수정/삭제 기능**도 함께 제공하도록 보완했습니다.
  - 이미지 수정 시, 모임 생성 시와 동일하게 form-data로 처리되며, 이미지 압축 기능(`compress_image` 함수)도 적용됩니다.
  - 관리자는 사용자 아이디를 리스트로 전달받고, 해당 아이디를 실제 User 모델의 `id`와 `ClubMember`의 `club_member_id`로 대체한 후, 기존 클럽 멤버 중 관리자인 멤버와 비교하여 역할을 업데이트합니다.
     1. 입력값 처리 (`process_request_data` 함수)
     2. user 객체 조회 - `user` 모델에서 기본키(id)를 얻어 실제 유저인지 조회하고 `admins` 값 대체
     3. 역할 업데이트
         - 이미 등록된 관리자(`ClubMember`의 role이 `admin`인 사용자)의 Id 목록과 2번 과정을 거친 id 목록 비교
         - 새로 추가된 관리자는 role을 `admin`으로 변경
         - 기존 관리자 중 새 관리자 리스트에 포함되지 않은 사용자는 role을 `member`로 변경

### [feat(clubs): 모임공통기능과 엔드포인트가 겹쳐 수정이 제대로 되지 않는 문제를 해결하기 위해 관리자인 경우 prefix 추가](https://github.com/iNESlab/Golbang_BE/commit/2964f75e84d0de89b8cddd62f79ae2b34cf6e944) 
- ASAP으로 진행되어, 관리자 전용 기능을 별도의 엔드포인트(`admin`)로 분리했습니다.
  - 이 변경 없이 진행할 경우, 모임 공통 기능 뷰와 엔드포인트가 충돌하여 PATCH 함수가 제대로 적용되지 않았습니다.
  - 앞으로 장기적으로 더 나은 방안을 마련할 예정입니다. 

![image](https://github.com/user-attachments/assets/efb78edd-b3e1-4591-a0b5-26d3c45efe35)

## ♻ 코드 리팩토링
### [rafact(clubs):club_member 뷰에서 사용하지 않는 import 문 제거](https://github.com/iNESlab/Golbang_BE/commit/a372bef1d6f3a46f7826bea4978415b854454030)
- 불필요한 import 문은 제거했습니다.

### 🖼️ 스크린샷 (선택)
> 초기 데이터
<img width="531" alt="스크린샷 2025-03-22 오전 12 50 55" src="https://github.com/user-attachments/assets/615b021f-e264-4579-8868-aae2b94cb660" />

>[!TIP]
> **이벤트 수정 (이미지 수정 없이 요청할 경우, JSON 요청)**
> 관리자는 리스트 형식으로 보내면 됩니다.
> Request: `{API}/clubs/admins/{club_id}/`
> ```json
> {
>    "name": "json테스트",
>    "description": "haha",
>    "admins": [16, 15]
>}
> ```
> <img width="1213" alt="스크린샷 2025-03-22 오전 12 51 03" src="https://github.com/user-attachments/assets/be834129-4c3b-4c1c-9a47-c864c14f9f0c" />

> [!TIP]
> **이미지 수정할 경우, form-data 요청**
> 관리자는 문자열로 묶어서 전송하면 됩니다.
> 예: 
> ```
> admins: '16, 15'
> ```
> <img width="1214" alt="스크린샷 2025-03-22 오전 12 51 46" src="https://github.com/user-attachments/assets/8d1cbc8c-f558-4eb3-bfd0-11c577e3da42" />

업데이트 후, 관리자로 잘 업데이트되고 이미지도 정상적으로 수정된 것을 확인할 수 있습니다. 

<img width="527" alt="스크린샷 2025-03-22 오전 12 51 08" src="https://github.com/user-attachments/assets/b4792567-d1fc-4626-b36b-8d102222d297" />

<img width="1069" alt="스크린샷 2025-03-22 오전 12 54 45" src="https://github.com/user-attachments/assets/950715be-ab3a-480d-83e4-6f419278c6b3" />


---

## 📌보완해야 할 점 (선택)
- ClubViewSet(모임 공통 기능)에서도 특정 모임 삭제 기능이 가능하여, 이와 관련해 **권한 분리가 제대로 이루어지지 않는 문제**가 있습니다.
- 현재는 임시 방편으로 관리자 전용 엔드포인트에 **admin prefix**를 추가했지만, **장기적으로 더 나은 솔루션**을 찾아 보완해야 합니다.
