### PR TITLE
Bugfix: 중첩 Response 반환 문제 수정 및 통계 계산 로직 분리

### DIFF
--- a/clubs/views/club_admin.py
+++ b/clubs/views/club_admin.py
@@ -160,7 +160,7 @@ class ClubAdminViewSet(ClubViewSet):
 
         # TODO: 다른 api와는 다르게 모임 초대할 때에는 PK가 아니라 유저 아이디로 초대하고 있음. 통일이 필요
 
-        # 존재하는 유저 필터링
+        # 존재하는 유저 필터링 (pk)
         existing_users = set(User.objects.filter(user_id__in=user_ids).values_list('id', flat=True))
         if not existing_users:  # 존재하는 유저가 없을 경우
             return handle_404_not_found('Users', user_ids)
@@ -168,12 +168,11 @@ class ClubAdminViewSet(ClubViewSet):
         # 이미 가입된 유저 필터링
         existing_members = set(ClubMember.objects.filter(club=club, user_id__in=existing_users).values_list('id', flat=True))
         new_users = existing_users - existing_members  # 가입되지 않은 유저만 초대
-
         if not new_users:  # 이미 모두 가입된 경우
             return handle_400_bad_request('All users are already members of the club')
 
         # 신규 ClubMember 객체 생성 (Bulk Create 사용)
-        new_members = [ClubMember(club=club, user_id=user_id, role='member') for user_id in new_users]
+        new_members = [ClubMember(club=club, user_id=account_id, role='member') for account_id in new_users]
         with transaction.atomic():  # 트랜잭션 사용
             ClubMember.objects.bulk_create(new_members)
 

--- a/golf_data/views.py
+++ b/golf_data/views.py
@@ -12,7 +12,6 @@ from rest_framework.response import Response
 from rest_framework.permissions import IsAuthenticated
 from django.shortcuts import get_object_or_404
 
-from utils.error_handlers import handle_404_not_found
 from .models import GolfClub
 from .serializers import GolfClubDetailSerializer, GolfClubListSerializer
 

--- a/participants/utils/statistics.py
+++ b/participants/utils/statistics.py
@@ -10,20 +10,18 @@ participants/utils/statistics.py
 from datetime import timedelta
 from django.db.models import Avg, Min
 
-from utils.error_handlers import handle_404_not_found
-
-
 def calculate_statistics(participants, start_date=None, end_date=None, year=None):
     """
     통계 데이터를 계산하고 응답 데이터를 생성하는 함수
+    에러 발생 시 None과 에러 메시지를 반환
     """
     if not participants.exists():
         if year:
-            return handle_404_not_found('participant data for the year', year)
+            return None, ('participant data for the year', year)
         elif start_date and end_date:
-            return handle_404_not_found('participant data for the given period', f"{start_date} to {end_date}")
+            return None, ('participant data for the given period', f"{start_date} to {end_date}")
         else:
-            return handle_404_not_found('participant data', 'for the user')
+            return None, ('participant data', 'for the user')
 
     # 평균 스코어 계산
     average_score = participants.aggregate(average=Avg('sum_score'))['average'] or 0
@@ -53,4 +51,4 @@ def calculate_statistics(participants, start_date=None, end_date=None, year=None
         "games_played": games_played
     } )
 
-    return data
+    return data, None

--- a/participants/views/statistics_view.py
+++ b/participants/views/statistics_view.py
@@ -58,7 +58,13 @@ class StatisticsViewSet(viewsets.ViewSet):
         user = request.user  # 요청을 보낸 사용자를 가져옴
         participants = Participant.objects.filter(club_member__user=user)  # 해당 사용자의 모든 참가 데이터
 
-        data = calculate_statistics(participants)
+        data, error = calculate_statistics(participants)
+        if error:
+            model_name, pk = error
+            return handle_404_not_found(model_name, pk)
+
+        if isinstance(data, Response):  # calculate_statistics 함수 내에서 예외처리 되었다면 Response가 생성됨
+            return data                 # 이미 Response면 그대로 리턴
 
         return Response({
             "status": status.HTTP_200_OK,
@@ -79,7 +85,10 @@ class StatisticsViewSet(viewsets.ViewSet):
         if not participants.exists():  # 해당 연도의 데이터가 없을 경우
             return handle_404_not_found('Statistics', f"for the year {year}")
 
-        data = calculate_statistics(participants, year=year)
+        data, error = calculate_statistics(participants, year=year)
+        if error:
+            model_name, pk = error
+            return handle_404_not_found(model_name, pk)
 
         return Response({
             "status": status.HTTP_200_OK,
@@ -115,7 +124,11 @@ class StatisticsViewSet(viewsets.ViewSet):
         if not participants.exists():  # 기간에 해당하는 데이터가 없을 경우
             return handle_404_not_found('Statistics', f"for the period {start_date} to {end_date}")
 
-        data = calculate_statistics(participants, start_date=start_date, end_date=end_date)
+        data, error = calculate_statistics(participants, start_date=start_date, end_date=end_date)
+        if error:
+            model_name, pk = error
+            return handle_404_not_found(model_name, pk)
+
         return Response({
             "status": status.HTTP_200_OK,
             "message": f"Successfully retrieved statistics for the period {start_date} to {end_date}",


### PR DESCRIPTION
### 🐛 버그 수정
[fix(statistics): Response가 이중으로 감싸지는 문제 해결](https://github.com/iNESlab/Golbang_BE/commit/f8aa98c8eb59d4ffb46597d10e7f5e5b59de8760) 
- **문제**
모임 생성 후 서버에서 반복적으로 `500 Internal Server Error`가 발생했습니다.
(로그: Internal Server Error: /api/v1/participants/statistics/overall/)

- **원인**
`calculate_statistics()` 함수가 상황에 따라 `Response` 객체를 직접 반환하면서 `Response(Response(...)) `형태가 되어 에러가 발생했습니다.
이는 함수가 데이터를 반환하거나 `Response` 객체를 반환하는 비일관적인 설계에서 비롯된 문제입니다.

- **해결을 위해 고려한 방식 비교**

기준 | ① `isinstance(data, Response)`로 감지하여 분기 처리 | ② `calculate_statistics()`를 순수 데이터 반환 함수로 리팩토링
-- | -- | --
역할 분리 | 함수 내부에 Presentation 로직 포함 → 단일 책임 원칙 위배 | 함수는 계산만, 응답은 View에서 처리 (SRP 준수)
가독성 | 호출부에서 조건문 추가 필요 | 호출부 로직이 직관적 (if error: return handle_404...)
테스트 용이성 | Response 객체를 목업하거나 파싱 필요 | 데이터 구조만 테스트하면 됨 (심플)
확장성 | 다른 컴포넌트에서 재사용 어려움 | 다양한 컨텍스트에서 유연하게 재사용 가능
디버깅/로깅 | 로직과 응답이 섞여 있어 추적 어려움 | 처리 흐름이 명확해 디버깅 쉬움


- **최종 선택**
② `calculate_statistics()`를 순수 데이터 반환 함수로 리팩토링

- 구현 방식
  - `calculate_statistics()`는 항상 `(data, error)` 튜플을 반환하도록 변경
  - `View`에서는 `if error:`로 분기 처리 후 `Response` 생성
  - 예외 응답은 `View`에서만 처리 → 책임 명확화 및 SRP 원칙 준수


> [!NOTE]
> ✅ 로컬 프론트엔드에서 새로운 유저로 테스트 완료했습니다. 에러가 나지 않는 점 확인했습니다.

### ♻ 코드 리팩토링
- [docs(clubs): 이해하기 쉬운 변수명으로 수정 (user_id -> account_id)](https://github.com/iNESlab/Golbang_BE/commit/99ce9202d3f25750f4ebd9dfef8a72a8846a5d2a)
  - for문 내 인자의 가독성을 높이기 위해 변수명을 수정했습니다.

- [refact: 사용하지 않는 error_handlers 임포트 제거](https://github.com/iNESlab/Golbang_BE/commit/615862ddd1dedfe6a7541e176f156a2df0977a57)
  - 더 이상 사용되지 않는 `error_handlers` 임포트를 정리했습니다.