### PR TITLE
Refactor: 참가자 캐싱 및 자동 동기화 

### DIFF
--- a/events/serializers.py
+++ b/events/serializers.py
@@ -52,7 +52,6 @@ class EventCreateUpdateSerializer(serializers.ModelSerializer):
             for participant in participant_data:
                 participant['event_id'] = event.pk
                 participant['member_id'] = participant['club_member'].pk  # 객체에서 다시 pk로 변경
-                participant['status_type'] = Participant.StatusType.ACCEPT
                 participant_serializer = ParticipantCreateUpdateSerializer(data=participant)
                 if participant_serializer.is_valid(raise_exception=True):
                     participant_serializer.save()

--- a/golbang/settings.py
+++ b/golbang/settings.py
@@ -174,7 +174,7 @@ CELERY_BEAT_SCHEDULE = {
     },
 }
 # settings.py (테스트 환경에서만 사용)
-CELERY_TASK_ALWAYS_EAGER = True
+CELERY_TASK_ALWAYS_EAGER = False
 CELERY_TASK_EAGER_PROPAGATES = True
 
 

--- a/participants/stroke/data_class.py
+++ b/participants/stroke/data_class.py
@@ -9,6 +9,7 @@ participa/stroke/data_class.py
 from dataclasses import dataclass
 from typing import Optional
 
+from participants.models import Participant
 
 @dataclass
 class ParticipantUpdateData:
@@ -20,35 +21,18 @@ class ParticipantUpdateData:
     is_group_win_handicap: Optional[bool]
 
     def __post_init__(self):
-        # rank와 handicap_rank가 bytes 타입인 경우 문자열로 디코딩
-        if isinstance(self.rank, bytes):
-            self.rank = self.rank.decode('utf-8')
-        if isinstance(self.handicap_rank, bytes):
-            self.handicap_rank = self.handicap_rank.decode('utf-8')
-        # is_group_win과 is_group_win_handicap이 bytes 타입인 경우 boolean으로 변환
-        if isinstance(self.is_group_win, bytes):
+        if isinstance(self.is_group_win, str):
             self.is_group_win = bool(int(self.is_group_win))
-        if isinstance(self.is_group_win_handicap, bytes):
+        if isinstance(self.is_group_win_handicap, str):
             self.is_group_win_handicap = bool(int(self.is_group_win_handicap))
 
 
 @dataclass
 class EventData:
-    group_win_team: Optional[str]           # 그룹 승리 팀
-    group_win_team_handicap: Optional[str]  # 핸디캡 적용 그룹 승리 팀
-    total_win_team: Optional[str]           # 전체 승리 팀
-    total_win_team_handicap: Optional[str]  # 핸디캡 적용 전체 승리 팀
-
-    def __post_init__(self):
-        # 필드들이 bytes 타입인 경우 문자열로 디코딩
-        if isinstance(self.group_win_team, bytes):
-            self.group_win_team = self.group_win_team.decode('utf-8')
-        if isinstance(self.group_win_team_handicap, bytes):
-            self.group_win_team_handicap = self.group_win_team_handicap.decode('utf-8')
-        if isinstance(self.total_win_team, bytes):
-            self.total_win_team = self.total_win_team.decode('utf-8')
-        if isinstance(self.total_win_team_handicap, bytes):
-            self.total_win_team_handicap = self.total_win_team_handicap.decode('utf-8')
+    group_win_team: str = "NONE"           # 그룹 승리 팀
+    group_win_team_handicap: str = "NONE"  # 핸디캡 적용 그룹 승리 팀
+    total_win_team: str = "NONE"           # 전체 승리 팀
+    total_win_team_handicap: str = "NONE"  # 핸디캡 적용 전체 승리 팀
 
 @dataclass
 class RankResponseData:
@@ -61,87 +45,70 @@ class RankResponseData:
     handicap_score: int
 
     def __post_init__(self):
-        if isinstance(self.participant_id, bytes):
-            self.participant_id = int(self.participant_id)
-        if isinstance(self.last_hole_number, bytes):
-            self.last_hole_number = int(self.last_hole_number)
-        if isinstance(self.last_score, bytes):
-            self.last_score = int(self.last_score)
-        if isinstance(self.rank, bytes):
-            self.rank = self.rank.decode('utf-8')
-        if isinstance(self.handicap_rank, bytes):
-            self.handicap_rank = self.handicap_rank.decode('utf-8')
-        if isinstance(self.sum_score, bytes):
-            self.sum_score = int(self.sum_score)
-        if isinstance(self.handicap_score, bytes):
-            self.handicap_score = int(self.handicap_score)
+        for attr in ['participant_id', 'last_hole_number', 'last_score', 'sum_score', 'handicap_score']:
+            value = getattr(self, attr)
+            if isinstance(value, str) and value.isdigit():
+                setattr(self, attr, int(value))
 
 @dataclass
-class ParticipantResponseData:
+class ParticipantRedisData:
     participant_id: int
-    user_name: chr
-    group_type: chr
-    team_type: chr
-    is_group_win: Optional[bool]
-    is_group_win_handicap: Optional[bool]
-    hole_number: int = 0
-    score: int = 0
-    sum_score: int = 0
-    handicap_score: int = 0
+    event_id: int
+    user_name: str
+    user_handicap: int
+    group_type: str
+    team_type: str
+    sum_score: int 
+    handicap_score: int
+    profile_image: Optional[str] = None
+    is_group_win: bool = False
+    is_group_win_handicap: bool = False
     rank: str = 'N/A'
     handicap_rank: str = 'N/A'
 
     def __post_init__(self):
         # 필드들이 bytes 타입인 경우 적절한 타입으로 변환
-        if isinstance(self.participant_id, bytes):
-            self.participant_id = int(self.participant_id)
-        if isinstance(self.user_name, bytes):
-            self.user_name = self.user_name.decode('utf-8')
-        if isinstance(self.group_type, bytes):
-            self.group_type = self.group_type.decode('utf-8')
-        if isinstance(self.team_type, bytes):
-            self.team_type = self.team_type.decode('utf-8')
-        if isinstance(self.rank, bytes):
-            self.rank = self.rank.decode('utf-8')
-        if isinstance(self.handicap_rank, bytes):
-            self.handicap_rank = self.handicap_rank.decode('utf-8')
-        if isinstance(self.sum_score, bytes):
-            self.sum_score = int(self.sum_score)
-        if isinstance(self.handicap_score, bytes):
-            self.handicap_score = int(self.handicap_score)
-        if isinstance(self.is_group_win, bytes):
-            self.is_group_win = bool(int(self.is_group_win))
-        if isinstance(self.is_group_win_handicap, bytes):
-            self.is_group_win_handicap = bool(int(self.is_group_win_handicap))
-        if isinstance(self.hole_number, bytes):
-            self.hole_number = int(self.hole_number)
-        if isinstance(self.score, bytes):
-            self.score = int(self.score)
+        for attr in ['participant_id', 'event_id', 'user_handicap', 'sum_score', 'handicap_score']:
+            value = getattr(self, attr)
+            if isinstance(value, str) and value.isdigit():
+                setattr(self, attr, int(value))
 
+        for attr in ['is_group_win', 'is_group_win_handicap']:
+            value = getattr(self, attr)
+            if isinstance(value, str) and value.isdigit():
+                setattr(self, attr, bool(int(value)))
 
-@dataclass
-class ParticipantRedisData:
-    participant_id: int
-    group_type: chr
-    team_type: chr
-    is_group_win: Optional[bool]
-    is_group_win_handicap: Optional[bool]
-    sum_score: int
-    handicap_score: int
-
-    def __post_init__(self):
-        # 필드들이 bytes 타입인 경우 적절한 타입으로 변환
-        if isinstance(self.participant_id, bytes):
-            self.participant_id = int(self.participant_id)
-        if isinstance(self.group_type, bytes):
-            self.group_type = self.group_type.decode('utf-8')
-        if isinstance(self.team_type, bytes):
-            self.team_type = self.team_type.decode('utf-8')
-        if isinstance(self.is_group_win, bytes):
-            self.is_group_win = bool(int(self.is_group_win))
-        if isinstance(self.is_group_win_handicap, bytes):
-            self.is_group_win_handicap = bool(int(self.is_group_win_handicap))
-        if isinstance(self.sum_score, bytes):
-            self.sum_score = int(self.sum_score)
-        if isinstance(self.handicap_score, bytes):
-            self.handicap_score = int(self.handicap_score)
+    @staticmethod
+    def orm_to_participant_redis(participant: Participant) -> "ParticipantRedisData":
+        return ParticipantRedisData(
+            participant_id=participant.pk,
+            profile_image=participant.club_member.user.profile_image.url if participant.club_member.user.profile_image else None,
+            event_id=participant.event.pk,
+            group_type=participant.group_type,
+            team_type=participant.team_type,
+            user_name=participant.club_member.user.name,
+            user_handicap=participant.club_member.user.handicap,
+            sum_score=participant.sum_score,
+            handicap_score=participant.handicap_score,
+            is_group_win=participant.is_group_win,
+            is_group_win_handicap=participant.is_group_win_handicap,
+            rank=participant.rank,
+            handicap_rank=participant.handicap_rank
+        )
+    
+    def to_redis_dict(self) -> dict[str, str]:
+        return {
+            "participant_id": str(self.participant_id),
+            'profile_image': self.profile_image if self.profile_image else '',
+            "event_id": str(self.event_id),
+            "user_name": self.user_name,
+            "user_handicap": str(self.user_handicap),
+            "group_type": self.group_type,
+            "team_type": self.team_type,
+            "sum_score": str(self.sum_score),
+            "handicap_score": str(self.handicap_score),
+            "is_group_win": "1" if self.is_group_win else "0",
+            "is_group_win_handicap": "1" if self.is_group_win_handicap else "0",
+            "rank": self.rank,
+            "handicap_rank": self.handicap_rank,
+        }

--- a/participants/stroke/mysql_interface.py
+++ b/participants/stroke/mysql_interface.py
@@ -6,34 +6,17 @@ participa/stroke/mysql_interface.py
 - MySQL 데이터베이스와 상호작용하는 클래스
 - 참가자와 이벤트의 데이터를 관리함
 '''
-import asyncio # 비동기 작업
 import logging
 from dataclasses import asdict
 
 from sympy import Q
 
-from asgiref.sync import sync_to_async # 비동기 작업을 동기 함수로 전환하기 위한 함수
 from channels.db import database_sync_to_async # 데이터베이스 작업을 비동기 함수로 전환하기 위한 함수
 
 from events.models import Event
 from participants.models import Participant, HoleScore
-from participants.stroke.data_class import ParticipantUpdateData, EventData
-from participants.stroke.redis_interface import redis_client
-
 
 class MySQLInterface:
-
-    @database_sync_to_async
-    def update_or_create_hole_score_in_db(self, participant_id, hole_number, score):
-        return HoleScore.objects.update_or_create(
-            participant_id=participant_id,
-            hole_number=hole_number,
-            defaults={'score': score}
-        )
-
-    @database_sync_to_async
-    def update_participant_rank_in_db(self, participant_id, participant_data):
-        Participant.objects.filter(id=participant_id).update(**asdict(participant_data))
 
     @database_sync_to_async
     def get_group_participants(self, event_id, group_type=None):
@@ -44,16 +27,18 @@ class MySQLInterface:
                     .filter(event_id=event_id, group_type=group_type)
                     .select_related('club_member__user'))
 
-    @database_sync_to_async
-    def get_event_participants(self, event_id):
-        # 특정 이벤트에 참여한 모든 참가자를 반환
-        return list(Participant.objects.filter(event_id=event_id).select_related('club_member__user'))
+    # @database_sync_to_async
+    # def get_event_participants(self, event_id):
+    #     # 특정 이벤트에 참여한 모든 참가자를 반환
+    #     return list(Participant.objects.filter(event_id=event_id).select_related('club_member__user'))
 
     @database_sync_to_async
     def get_and_check_participant(self, participant_id, user):
         # 주어진 참가자 ID와 일치하는 참가자 정보를 가져오고, 해당 사용자인지 확인
         try:
             participant = Participant.objects.select_related('club_member__user', 'event').get(id=participant_id)
+            logging.info('participant: %s', participant.club_member.user.name)
+            logging.info('user: %s', user.name)
             if participant.club_member.user != user:
                 return None
             return participant
@@ -67,101 +52,27 @@ class MySQLInterface:
         except Participant.DoesNotExist:
             return None
 
-    # 원래는 redis를 그대로 저장하면 되는데, 너무 길어져서 그냥 event 모델의 method 이용
-    async def determine_and_update_win_status(self, participant, event):
-        # 한 참가자를 기준으로 조별 및 전체 승리 팀을 결정하고 업데이트
-        # participant: 한 조의 한 참가자를 의미 (한명 바꿔도 같은 조의 모든 인원이 갱신되기 때문)
-        if not participant:
-            logging.warning('No participants found for event_id: %s', event.id)
-            return
+    # # 원래는 redis를 그대로 저장하면 되는데, 너무 길어져서 그냥 event 모델의 method 이용
+    # async def determine_and_update_win_status(self, participant, event):
+    #     # 한 참가자를 기준으로 조별 및 전체 승리 팀을 결정하고 업데이트
+    #     # participant: 한 조의 한 참가자를 의미 (한명 바꿔도 같은 조의 모든 인원이 갱신되기 때문)
+    #     if not participant:
+    #         logging.warning('No participants found for event_id: %s', event.id)
+    #         return
 
-        # 조별 승리 여부 갱신
-        participant.determine_is_group_win()
-        participant.determine_is_group_win_handicap()
+    #     # 조별 승리 여부 갱신
+    #     participant.determine_is_group_win()
+    #     participant.determine_is_group_win_handicap()
 
-        # 이벤트 전체 승리팀 결정
-        event.determine_group_win_team()
-        event.determine_group_win_team_handicap()
-        event.determine_total_win_team()
-        event.determine_total_win_team_handicap()
+    #     # 이벤트 전체 승리팀 결정
+    #     event.determine_group_win_team()
+    #     event.determine_group_win_team_handicap()
+    #     event.determine_total_win_team()
+    #     event.determine_total_win_team_handicap()
 
-        # 최종적으로 데이터베이스에 저장
-        await sync_to_async(participant.save)()
-        await sync_to_async(event.save)()
+    #     # 최종적으로 데이터베이스에 저장
+    #     await sync_to_async(participant.save)()
+    #     await sync_to_async(event.save)()
 
-    @database_sync_to_async
-    def update_event_data_in_db(self, event_id, event_data):
-        # 이벤트 데이터 업데이트
-        Event.objects.filter(id=event_id).update(**asdict(event_data))
+    
 
-    async def transfer_participant_data_to_db(self, event_id, participants):
-        from clubs.models import ClubMember
-        try:
-            # Redis에서 참가자 데이터를 가져와서 MySQL로 전달
-            for participant in participants:
-                redis_key = f'event:{event_id}:participant:{participant.id}'
-                logging.info('redis_key: %s', redis_key)
-
-                participant_data_dict = await sync_to_async(redis_client.hgetall)(redis_key)
-                logging.info('participant_data_dict: %s', participant_data_dict)
-
-                # ParticipantUpdateData 객체 생성
-                participant_data = ParticipantUpdateData(
-                    rank=participant_data_dict.get(b"rank"),
-                    handicap_rank=participant_data_dict.get(b"handicap_rank"),
-                    sum_score=participant_data_dict.get(b"sum_score"),
-                    handicap_score=participant_data_dict.get(b"handicap_score"),
-                    is_group_win=participant_data_dict.get(b"is_group_win"),
-                    is_group_win_handicap=participant_data_dict.get(b"is_group_win_handicap")
-                )
-
-                if participant_data.rank is not None and participant_data.handicap_rank is not None:
-                    await self.update_participant_rank_in_db(participant.id, participant_data)
-
-                # 참가자 포인트 계산 및 저장
-                await sync_to_async(participant.calculate_points)()
-
-        except Exception as e:
-            logging.error(f"Error updating participant data: {e}")
-
-        # 모든 참가자의 포인트 계산이 끝난 후, 클럽 멤버들의 총 포인트 업데이트
-        try:
-            club = participants[0].event.club  # 첫 번째 참가자가 속한 모임을 가져옴 (모든 참가자가 동일한 클럽에 속해있음)
-            for member in ClubMember.objects.filter(club=club):
-                await sync_to_async(member.update_total_points)()
-
-            # 클럽 멤버들의 평균 점수 및 핸디캡 점수 랭킹 업데이트
-            await sync_to_async(ClubMember.calculate_avg_rank)(club)
-            await sync_to_async(ClubMember.calculate_handicap_avg_rank)(club)
-
-        except Exception as e:
-            logging.error(f"Error updating club member points or ranks: {e}")
-
-    async def transfer_hole_scores_to_db(self, participants):
-        # Redis에서 홀 점수를 가져와서 MySQL로 전달
-        for participant in participants:
-            score_keys_pattern = f'participant:{participant.id}:hole:*'
-            score_keys = await sync_to_async(redis_client.keys)(score_keys_pattern)
-            logging.info('score_keys: %s', score_keys)
-
-            async def update_or_create_hole_score(key):
-                hole_number = int(key.decode('utf-8').split(':')[-1])
-                score = int(await sync_to_async(redis_client.get)(key))
-                await self.update_or_create_hole_score_in_db(participant.id, hole_number, score)
-
-            await asyncio.gather(*(update_or_create_hole_score(key) for key in score_keys))
-
-    async def transfer_event_data_to_db(self, event_id):
-        # Redis에서 이벤트 데이터를 가져와서 MySQL로 전달
-        event_key = f'event:{event_id}'
-        event_data_dict = await sync_to_async(redis_client.hgetall)(event_key)
-
-        # EventData 객체 생성
-        event_data = EventData(
-            group_win_team=event_data_dict.get(b"group_win_team"),
-            group_win_team_handicap=event_data_dict.get(b"group_win_team_handicap"),
-            total_win_team=event_data_dict.get(b"total_win_team"),
-            total_win_team_handicap=event_data_dict.get(b"total_win_team_handicap")
-        )
-
-        await self.update_event_data_in_db(event_id, event_data)

--- a/participants/stroke/stroke_event_consumers.py
+++ b/participants/stroke/stroke_event_consumers.py
@@ -9,11 +9,13 @@ import json
 import logging
 import asyncio
 from dataclasses import asdict
+from typing import List
 
 from asgiref.sync import sync_to_async
 from channels.generic.websocket import AsyncWebsocketConsumer
 
-from participants.stroke.data_class import RankResponseData
+from participants.models import Participant
+from participants.stroke.data_class import ParticipantRedisData, RankResponseData
 from participants.stroke.mysql_interface import MySQLInterface
 from participants.stroke.redis_interface import redis_client, RedisInterface
 
@@ -40,7 +42,15 @@ class EventParticipantConsumer(AsyncWebsocketConsumer, MySQLInterface, RedisInte
             self.participant_id = self.scope['url_route']['kwargs']['participant_id']
             logging.debug(f'Participant ID: {self.participant_id}')
 
-            participant = await self.get_and_check_participant(self.participant_id, user)
+            # participant = await self.get_and_check_participant(self.participant_id, user) # mysql 연결
+            participant: ParticipantRedisData = await self.get_participant_from_redis(self.event_id,self.participant_id) # redis에서 참가자 정보 가져오기
+            if participant is None:
+                participant_mysql: Participant = await self.get_and_check_participant(self.participant_id, user) # mysql 연결
+                if participant_mysql is None:
+                    participant = None
+                else:
+                    participant = await self.save_participant_in_redis(participant_mysql)  # ✅ 캐싱 추가
+            
             if participant is None:
                 logging.info('No participant')
                 await self.close(code=4004)
@@ -99,7 +109,7 @@ class EventParticipantConsumer(AsyncWebsocketConsumer, MySQLInterface, RedisInte
         try:
             event_data = await self.get_event_data_from_redis(self.event_id)
             # 모든 참가자와 관련된 정보를 한 번의 쿼리로 가져옴
-            participants = await self.get_event_participants(self.event_id)
+            participants: List[ParticipantRedisData] = await self.get_event_participants_from_redis(self.event_id)
             logging.info('participants: {}'.format(participants))
 
             ranks = await asyncio.gather(*[
@@ -123,36 +133,28 @@ class EventParticipantConsumer(AsyncWebsocketConsumer, MySQLInterface, RedisInte
         except Exception as e:
             await self.send_json({'error': f'스코어 기록을 가져오는 데 실패했습니다.{e}'})
 
-    async def process_participant(self, participant):
+    async def process_participant(self, participant: ParticipantRedisData):
         # 참가자 데이터를 처리하여 rank 정보를 반환
 
-        participant_id = participant.id
-        rank_data = await self.get_event_rank_from_redis(participant.event_id, participant_id)
+        rank_data = await self.get_event_rank_from_redis(participant.event_id, participant)
 
         # 아직 점수입력이 안된 참가자는 제외
         if rank_data.sum_score == 0:
             return None
 
-        user = participant.club_member.user
-
         return {
             'user': {
-                'name': user.name,
-                'profile_image' : user.profile_image.url if user.profile_image else None,
+                'name': participant.user_name,
+                'profile_image' : participant.profile_image,
             },
             **asdict(rank_data)  # RankData 객체를 딕셔너리로 변환 후 펼침
         }
 
-    async def get_event_rank_from_redis(self, event_id, participant_id):
+    async def get_event_rank_from_redis(self, event_id, participant: ParticipantRedisData):
         # Redis에서 참가자의 랭킹 정보를 가져옴
 
         logging.info('Fetching hole scores from Redis')
-        redis_key = f'event:{event_id}:participant:{participant_id}'
-
-        rank = await sync_to_async(redis_client.hget)(redis_key, "rank")
-        handicap_rank = await sync_to_async(redis_client.hget)(redis_key, "handicap_rank")
-        sum_score = await sync_to_async(redis_client.hget)(redis_key, "sum_score")
-        handicap_score = await sync_to_async(redis_client.hget)(redis_key, "handicap_score")
+        participant_id = participant.participant_id
 
         # 홀 번호와 점수를 저장하기 위한 초기 변수 설정
         last_hole_number = 0
@@ -164,21 +166,21 @@ class EventParticipantConsumer(AsyncWebsocketConsumer, MySQLInterface, RedisInte
 
         if keys:
             # keys를 내림차순으로 정렬
-            keys.sort(reverse=True, key=lambda k: int(k.decode('utf-8').split(':')[-1]))
+            keys.sort(reverse=True, key=lambda k: int(k.split(':')[-1]))
 
             # 가장 큰 hole_number와 그에 해당하는 score를 가져옴
             last_key = keys[0]
-            last_hole_number = int(last_key.decode('utf-8').split(':')[-1])
+            last_hole_number = int(last_key.split(':')[-1])
             last_score = int(await sync_to_async(redis_client.get)(last_key))
 
         return RankResponseData(
             participant_id=participant_id,
             last_hole_number=last_hole_number,
             last_score=last_score,
-            rank=rank.decode('utf-8') if rank else None,
-            handicap_rank=handicap_rank.decode('utf-8') if handicap_rank else None,
-            sum_score=int(sum_score) if sum_score else 0,
-            handicap_score=int(handicap_score) if handicap_score else 0
+            rank=participant.rank,
+            handicap_rank=participant.handicap_rank,
+            sum_score=participant.sum_score,
+            handicap_score=participant.handicap_score,
         )
 
     async def send_ranks_periodically(self):

--- a/participants/tasks.py
+++ b/participants/tasks.py
@@ -1,0 +1,148 @@
+from dataclasses import asdict
+import logging
+import time
+
+from django.db import transaction
+from celery import shared_task
+# from participants.stroke.mysql_interface import MySQLInterfaceSync
+from events.models import Event
+from participants.models import HoleScore, Participant
+from participants.stroke.data_class import EventData, ParticipantUpdateData
+from participants.stroke.redis_interface import redis_client
+
+
+@shared_task
+def save_event_periodically_task(event_id: int):
+
+    print(f"event:[{event_id}] migrate start")
+
+    mysql_client = MigrationMySQLInterface()
+    key = f"event:{event_id}:is_saving"
+    while True:
+        try:
+            with transaction.atomic():
+                participants = mysql_client.get_event_participants(event_id)
+                mysql_client.transfer_participant_data_to_db(event_id, participants)
+                mysql_client.transfer_hole_scores_to_db(participants)
+                mysql_client.transfer_event_data_to_db(event_id)
+            print(f"event:[{event_id}] 저장 완료")
+
+        except Exception as e:
+            print(f"event[{event_id}] 저장 실패: {e}")
+
+        print("test1")
+        exists = redis_client.exists(key)
+        print(f"[{event_id}] is_saving 키 존재 여부: {exists}")
+        if not exists:
+            print(f"[{event_id}] is_saving 키 없음 → 저장 종료")
+            break
+
+        count = redis_client.get(key)
+        print(f"[{event_id}] 참가자 수: {count}")
+        if count is not None and int(count) <= 0:
+            print(f"[{event_id}] 참가자 0명 → 저장 종료")
+            redis_client.delete(key)
+            break
+
+        time.sleep(30)
+
+
+class MigrationMySQLInterface:
+        def get_event_participants(self, event_id):
+        # 특정 이벤트에 참여한 모든 참가자를 반환
+            return list(Participant.objects.filter(event_id=event_id))
+        
+        def transfer_participant_data_to_db(self, event_id, participants):
+            from clubs.models import ClubMember
+            try:
+                print('transfer_participant_data_to_db 실행')
+                # Redis에서 참가자 데이터를 가져와서 MySQL로 전달
+                for participant in participants:
+                    redis_key = f'event:{event_id}:participant:{participant.pk}'
+                    logging.info('redis_key: %s', redis_key)
+
+                    participant_data_dict = redis_client.hgetall(redis_key)
+                    logging.info('participant_data_dict: %s', participant_data_dict)
+
+                    # ParticipantUpdateData 객체 생성
+                    participant_data = ParticipantUpdateData(
+                        rank=participant_data_dict.get(b"rank"),
+                        handicap_rank=participant_data_dict.get(b"handicap_rank"),
+                        sum_score=participant_data_dict.get(b"sum_score"),
+                        handicap_score=participant_data_dict.get(b"handicap_score"),
+                        is_group_win=participant_data_dict.get(b"is_group_win"),
+                        is_group_win_handicap=participant_data_dict.get(b"is_group_win_handicap")
+                    )
+
+                    if participant_data.rank is not None and participant_data.handicap_rank is not None:
+                        self.update_participant_rank_in_db(participant.pk, participant_data)
+
+                    # 참가자 포인트 계산 및 저장
+                    participant.calculate_points()
+                    print(f"Participant ID: {participant.pk}, Rank: {participant.rank}, Handicap Rank: {participant.handicap_rank}")
+
+            except Exception as e:
+                logging.error(f"Error updating participant data: {e}")
+
+            # 모든 참가자의 포인트 계산이 끝난 후, 클럽 멤버들의 총 포인트 업데이트
+            try:
+                club = participants[0].event.club  # 첫 번째 참가자가 속한 모임을 가져옴 (모든 참가자가 동일한 클럽에 속해있음)
+                for member in ClubMember.objects.filter(club=club):
+                    member.update_total_points()
+
+                    # 클럽 멤버들의 평균 점수 및 핸디캡 점수 랭킹 업데이트
+                    ClubMember.calculate_avg_rank(club)
+                    ClubMember.calculate_handicap_avg_rank(club)
+
+            except Exception as e:
+                logging.error(f"Error updating club member points or ranks: {e}")
+
+        def transfer_hole_scores_to_db(self, participants):
+            print('transfer_hole_Scores_to_db 실행')
+            # Redis에서 홀 점수를 가져와서 MySQL로 전달
+            for participant in participants:
+                score_keys_pattern = f'participant:{participant.pk}:hole:*'
+                score_keys = redis_client.keys(score_keys_pattern)
+                logging.info('score_keys: %s', score_keys)
+
+                for key in score_keys:
+                    hole_number = int(key.decode('utf-8').split(':')[-1])
+                    score = int(redis_client.get(key))  # ✅ 동기 호출
+                    self.update_or_create_hole_score_in_db(participant.pk, hole_number, score)
+            print('transfer_hole_Scores_to_db 실행종료')
+
+        def transfer_event_data_to_db(self, event_id):
+            print('transfer_event_data_to_db 실행')
+            # Redis에서 이벤트 데이터를 가져와서 MySQL로 전달
+            event_key = f'event:{event_id}'
+
+            if(not redis_client.exists(event_key)):
+                print(f"event:{event_id} 키가 존재하지 않습니다. 팀 게임이 아닙니다.")
+                return
+            
+            event_data_dict = redis_client.hgetall(event_key)
+
+            # EventData 객체 생성
+            event_data = EventData(
+                group_win_team=event_data_dict.get(b"group_win_team"),
+                group_win_team_handicap=event_data_dict.get(b"group_win_team_handicap"),
+                total_win_team=event_data_dict.get(b"total_win_team"),
+                total_win_team_handicap=event_data_dict.get(b"total_win_team_handicap")
+            )
+
+            self.update_event_data_in_db(event_id, event_data)
+            print('transfer_event_data_to_db 실행종료')
+
+        def update_participant_rank_in_db(self, participant_id, participant_data):
+            Participant.objects.filter(id=participant_id).update(**asdict(participant_data))
+        
+        def update_event_data_in_db(self, event_id, event_data):
+        # 이벤트 데이터 업데이트
+            Event.objects.filter(id=event_id).update(**asdict(event_data))
+
+        def update_or_create_hole_score_in_db(self, participant_id, hole_number, score):
+            return HoleScore.objects.update_or_create(
+                participant_id=participant_id,
+                hole_number=hole_number,
+                defaults={'score': score}
+            )


### PR DESCRIPTION
### ✨기능 추가
[feat: redis <-> mysql 동기화](https://github.com/iNESlab/Golbang_BE/commit/069662e392a1da6126fa64d08a413cdce792cc0b) 

-  celery 비동기 설정 활성화
- celery에서 최대 6시간(키의 유효시간)동안 자동 동기화
- 테스트 용도로 30초 간격으로 동기화
- mysql 동기화 로직 이동 및 안쓰는 코드 주석처리

동기화 로그 
<img width="859" alt="image" src="https://github.com/user-attachments/assets/b2a932a2-884f-4205-a123-b2262444e283" />


### ♻ 코드 리팩토링
[Refactor: redis_client, 참가자 캐싱, 참가자 카운팅](https://github.com/iNESlab/Golbang_BE/commit/cff864e820b9494b1584e6bcba2381289a831fb7) 

- redis_client 옵션 변경(시간 제한, str 변환 응답)
- 처음 조회된 참가자는 mysql에서 읽어서 redis에 저장
- 이후, 모든 수정은 redis에서 진행
- 참가자 수를 카운팅 하여 모두 나가면, redis<->mysql이 동기화되는 로직

### 🔧 구성 파일 추가
2번째 커밋에서 celery 관련 설정파일 변경했습니다. 참고해주세요.
계속 안됐는데 처음에 저 설정을 몰라서 하루 정도 디버깅했는데... 뭘해도 답이 없더라구요
(저게 True면, 웹소켓과 같은 비동기 통신에서 셀러리를 비동기로 호출이 안되는거 같아요)

간신히 저 설정을 알았는데,
혹..시 다른 celery 기능은 저걸 꺼야하는거면 자동 동기화 기능은 사용하지 못할거 같습니다..ㅎ

### 🙈 기타(ex..gitignore 추가/수정)
- [fix: 테스트를 위해 강제 참석하던 로직 초기화](https://github.com/iNESlab/Golbang_BE/commit/38ae532e74aed399f857b04192371a4313e6b62e) 

  - 참고: 저 로직이 있어도 안됐었음;;ㅜㅜ

- try-catch finally는 GPT말로는 redis_client를 저희처럼 쓰는 방식에서는 굳이 close 안된다고 하네요.
redis_client를 커스텀하는 다른 코드(`redis_client = await aioredis.from_url(...)`)가 있던데,
이런건 꼭 닫아야 하구, 저희는 하나의 인스턴스만 쓴다고 괜찮다네요

- 아직 locust? 그 트래픽 툴로 테스트는 안해봤어요. 로컬이라 테스트하기 어려워서... 배포하고 해보려고 합니다.
- 어쩌다보니 확인했는데, mariadb docker는  connections가 150개더라구요;;; mariadb > rds (?)

### 사진 
- 유저 하나로만 테스트했는데, 스코어 입력 / 랭킹 조회 잘됩니다
![image](https://github.com/user-attachments/assets/aaff03b0-0c7b-4286-987f-c5b4cf1d995a)

