### PR TITLE
hotfix: 점수 합계 변경이 안되던 버그 및 프론트에 int가 아닌 string으로 보내던 버그 수정

### DIFF
--- a/participants/stroke/data_class.py
+++ b/participants/stroke/data_class.py
@@ -47,8 +47,11 @@ class RankResponseData:
     def __post_init__(self):
         for attr in ['participant_id', 'last_hole_number', 'last_score', 'sum_score', 'handicap_score']:
             value = getattr(self, attr)
-            if isinstance(value, str) and value.isdigit():
-                setattr(self, attr, int(value))
+            if isinstance(value, str):
+                try:
+                    setattr(self, attr, int(value)) # 음수도 int로 변환
+                except (ValueError, TypeError):
+                    pass
 
 @dataclass
 class ParticipantRedisData:

--- a/participants/stroke/data_class.py
+++ b/participants/stroke/data_class.py
@@ -70,8 +70,11 @@ class ParticipantRedisData:
         # 필드들이 bytes 타입인 경우 적절한 타입으로 변환
         for attr in ['participant_id', 'event_id', 'user_handicap', 'sum_score', 'handicap_score']:
             value = getattr(self, attr)
-            if isinstance(value, str) and value.isdigit():
-                setattr(self, attr, int(value))
+            if isinstance(value, str):
+                try:
+                    setattr(self, attr, int(value)) # 음수도 int로 변환
+                except (ValueError, TypeError):
+                    pass
 
         for attr in ['is_group_win', 'is_group_win_handicap']:
             value = getattr(self, attr)

--- a/participants/stroke/redis_interface.py
+++ b/participants/stroke/redis_interface.py
@@ -9,8 +9,10 @@ participa/stroke/redis_interface.py
 from dataclasses import asdict
 import json
 import logging
+from multiprocessing.pool import AsyncResult
 
 from asgiref.sync import sync_to_async
+from participants.tasks import save_event_periodically_task
 import redis
 
 from golbang import settings
@@ -39,27 +41,59 @@ class RedisInterface:
 
         if count <= 0:
             await sync_to_async(redis_client.delete)(key)
-            logging.info(f"[{event_id}] 모든 참가자 퇴장 → 마이그레이션 종료")
+            logging.info(f"[{event_id}] 모든 참가자 퇴장 → count 보관 키 삭제")
     
     
-    async def save_is_event_auto_migration_in_redis(self, event_id):
+    async def save_celery_event_from_redis_to_mysql(self, event_id, is_count_incr = True):
         '''
-        이 키가 레디스에 저장돼있으면,
+        key가 레디스에 저장돼있으면,
         redis에서 mysql로 정기적(xx초 간격)으로 마이그레이션 되는 것을 의미
+        task_key는 celery 작업 상태 추적키
         '''
         key = f"event:{event_id}:is_saving"
+        task_key = f"{key}:task_id"
+
+        # 1️⃣ 먼저 task_key 존재 + 상태 확인
+        if await sync_to_async(redis_client.exists)(task_key):
+            task_id = await sync_to_async(redis_client.get)(task_key)
+            if task_id:
+                result = AsyncResult(task_id)
+                if result.status in ['PENDING', 'STARTED']:
+                    # ✅ 현재 Celery 작업이 진행 중이면 → key만 다시 세팅
+                    await sync_to_async(redis_client.setnx)(key, 1)
+                    await sync_to_async(redis_client.expire)(key, 1800)
+                    logging.info(f"[{event_id}] 기존 Celery task 실행 중 → key만 재설정")
+                    return
+                else:
+                    # ✅ 종료된 task → task_key 제거
+                    logging.info(f"[{event_id}] 기존 Celery task 종료됨 → task_key 삭제")
+                    await sync_to_async(redis_client.delete)(task_key)
+                    
+        # task_key가 없으면 새로 생성
+        task_set = await sync_to_async(redis_client.setnx)(task_key, "creating")
+
+        if task_set:
+            task = save_event_periodically_task.delay(event_id)
+            await sync_to_async(redis_client.set)(task_key, task.id)
+            await sync_to_async(redis_client.expire)(task_key, 86400) # 하루 동안 유지
+
+        # 2️⃣ 여기까지 왔으면 → 새 작업 실행 가능
         created = await sync_to_async(redis_client.setnx)(key, 1)
 
         if created:
             # ✅ 처음 생성된 경우 → Celery Task 시작
-            logging.info(f"[{event_id}] 마이그레이션 시작됨")
-            await sync_to_async(redis_client.expire)(key, 21600) # 6시간 동안 유지
-            return True
-        else:
-            # 이미 존재하는 경우, count 증가
-            logging.info(f"[{event_id}] 기존 마이그레이션 중 → count 증가")
+            logging.info(f"[{event_id}] 마이그레이션 기본키 생성")
+            await sync_to_async(redis_client.expire)(key, 1800) # 30분 동안 유지
+        elif is_count_incr:
+            # 이미 존재하는 경우, count 증가 (count 0이면 키 제거)
+            logging.info(f"[{event_id}] 이미 마이그레이션 중 → count 증가")
             await sync_to_async(redis_client.incr)(key)
-            return False
+            await sync_to_async(redis_client.expire)(key, 1800) # 30분 갱신
+        else:
+            logging.info(f"[{event_id}] 이미 마이그레이션 중 → 기본키 유효기간 갱신")
+            await sync_to_async(redis_client.expire)(key, 1800) # 30분 갱신
+
+
 
     async def save_participant_in_redis(self, participant: Participant):
         # 참가자 Redis 캐싱 메서드

--- a/participants/stroke/stroke_event_consumers.py
+++ b/participants/stroke/stroke_event_consumers.py
@@ -42,18 +42,12 @@ class EventParticipantConsumer(AsyncWebsocketConsumer, MySQLInterface, RedisInte
             self.participant_id = self.scope['url_route']['kwargs']['participant_id']
             logging.debug(f'Participant ID: {self.participant_id}')
 
-            # participant = await self.get_and_check_participant(self.participant_id, user) # mysql 연결
             participant: ParticipantRedisData = await self.get_participant_from_redis(self.event_id,self.participant_id) # redis에서 참가자 정보 가져오기
-            if participant is None:
-                participant_mysql: Participant = await self.get_and_check_participant(self.participant_id, user) # mysql 연결
-                if participant_mysql is None:
-                    participant = None
-                else:
-                    participant = await self.save_participant_in_redis(participant_mysql)  # ✅ 캐싱 추가
             
             if participant is None:
                 logging.info('No participant')
-                await self.close(code=4004)
+                await self.send_json({'status': 404, 'error': f"Participant[{self.participant_id}] not found"})
+                await self.close(code=404)
                 return
 
             self.event_id = participant.event_id
@@ -72,8 +66,8 @@ class EventParticipantConsumer(AsyncWebsocketConsumer, MySQLInterface, RedisInte
 
         except Exception as e:
             logging.error(f'Error in connect: {e}')
-            await self.send_json({'error': str(e)})
-            await self.close(code=4005)
+            await self.send_json({'status': 500, 'error': str(e)})
+            await self.close(code=5000)
 
     async def disconnect(self, close_code):
         try:
@@ -86,6 +80,7 @@ class EventParticipantConsumer(AsyncWebsocketConsumer, MySQLInterface, RedisInte
                 self.send_task.cancel()  # 주기적인 태스크 취소
                 logging.debug('Cancelled send_scores_periodically task')
         except Exception as e:
+            await self.send_json({'status': 500, 'error': str(e)})
             logging.error(f'Error in disconnect: {e}')
 
     async def receive(self, text_data=None, bytes_data=None, **kwargs):
@@ -99,7 +94,7 @@ class EventParticipantConsumer(AsyncWebsocketConsumer, MySQLInterface, RedisInte
 
         except Exception as e:
             logging.error(f'error in receive: {e}')
-            await self.send_json({'status': 400, 'message': str(e)})
+            await self.send_json({'status': 400, 'error': str(e)})
 
     @staticmethod
     def get_event_group_name(event_id):
@@ -131,7 +126,7 @@ class EventParticipantConsumer(AsyncWebsocketConsumer, MySQLInterface, RedisInte
             print(f'response_data: {response_data}')
             await self.send_json(response_data)
         except Exception as e:
-            await self.send_json({'error': f'스코어 기록을 가져오는 데 실패했습니다.{e}'})
+            await self.send_json({'status':500,'error': f'스코어 기록을 가져오는 데 실패했습니다.{e}'})
 
     async def process_participant(self, participant: ParticipantRedisData):
         # 참가자 데이터를 처리하여 rank 정보를 반환
@@ -193,15 +188,24 @@ class EventParticipantConsumer(AsyncWebsocketConsumer, MySQLInterface, RedisInte
 
             except Exception as e:
                 logging.error(f'Error in send_scores_periodically: {e}')
-                await self.send_json({'error': '주기적인 스코어 전송 실패', 'details': str(e)})
+                await self.send_json({'status':500, 'error': '주기적인 스코어 전송 실패', 'details': str(e)})
             await asyncio.sleep(300)  # 5분마다 주기적으로 스코어 전송
 
     async def send_json(self, content):
         # JSON 데이터를 WebSocket을 통해 전송
 
         try:
-            logging.debug(f'Sending JSON: {content}')
+            logging.debug(f'Sending JSON: {content}') 
+            #TODO: 응답할 때, 아래처럼 보내도록 변경 지금은 날것으로 보내고 있어서 프론트에서 에러핸들링하기 어려움
+            '''
+            await self.send_json({
+                'status': 200,
+                'message': 'success',
+                'data': content
+            })
+            '''
             await self.send(text_data=json.dumps(content, ensure_ascii=False))
             logging.debug('JSON sent successfully')
         except Exception as e:
             logging.error(f'Error in send_json: {e}')
+            await self.send_json({'status':500, 'error': f'Error in send_json: {e}'})

--- a/participants/tasks.py
+++ b/participants/tasks.py
@@ -8,16 +8,20 @@ from celery import shared_task
 from events.models import Event
 from participants.models import HoleScore, Participant
 from participants.stroke.data_class import EventData, ParticipantUpdateData
-from participants.stroke.redis_interface import redis_client
+
 
 
 @shared_task
 def save_event_periodically_task(event_id: int):
+    from participants.stroke.redis_interface import redis_client 
+    # 지연 호출로 처음에 task가 준비되기 전에 redisInterface에서 호출하는 것을 방지
 
-    print(f"event:[{event_id}] migrate start")
+    print(f"event:[{event_id}] 자동 저장(동기화) 시작")
 
     mysql_client = MigrationMySQLInterface()
     key = f"event:{event_id}:is_saving"
+    task_key = f"{key}:task_id"
+
     while True:
         try:
             with transaction.atomic():
@@ -25,124 +29,128 @@ def save_event_periodically_task(event_id: int):
                 mysql_client.transfer_participant_data_to_db(event_id, participants)
                 mysql_client.transfer_hole_scores_to_db(participants)
                 mysql_client.transfer_event_data_to_db(event_id)
-            print(f"event:[{event_id}] 저장 완료")
+            print(f"event:[{event_id}] 동기화 완료")
 
         except Exception as e:
-            print(f"event[{event_id}] 저장 실패: {e}")
+            print(f"event[{event_id}] 동기화 실패: {e}")
 
         print("test1")
         exists = redis_client.exists(key)
-        print(f"[{event_id}] is_saving 키 존재 여부: {exists}")
-        if not exists:
-            print(f"[{event_id}] is_saving 키 없음 → 저장 종료")
+        if not exists :
+            print(f"[{event_id}] is_saving 키 없음 → 동기화 종료")
+            redis_client.delete(task_key)
             break
 
         count = redis_client.get(key)
         print(f"[{event_id}] 참가자 수: {count}")
         if count is not None and int(count) <= 0:
-            print(f"[{event_id}] 참가자 0명 → 저장 종료")
+            print(f"[{event_id}] 참가자 0명 → 동기화 종료")
             redis_client.delete(key)
+            redis_client.delete(task_key)
             break
 
         time.sleep(30)
 
 
 class MigrationMySQLInterface:
-        def get_event_participants(self, event_id):
-        # 특정 이벤트에 참여한 모든 참가자를 반환
-            return list(Participant.objects.filter(event_id=event_id))
-        
-        def transfer_participant_data_to_db(self, event_id, participants):
-            from clubs.models import ClubMember
-            try:
-                print('transfer_participant_data_to_db 실행')
-                # Redis에서 참가자 데이터를 가져와서 MySQL로 전달
-                for participant in participants:
-                    redis_key = f'event:{event_id}:participant:{participant.pk}'
-                    logging.info('redis_key: %s', redis_key)
+    def __init__(self):
+        from participants.stroke.redis_interface import redis_client
+        self.redis_client = redis_client
 
-                    participant_data_dict = redis_client.hgetall(redis_key)
-                    logging.info('participant_data_dict: %s', participant_data_dict)
-
-                    # ParticipantUpdateData 객체 생성
-                    participant_data = ParticipantUpdateData(
-                        rank=participant_data_dict.get(b"rank"),
-                        handicap_rank=participant_data_dict.get(b"handicap_rank"),
-                        sum_score=participant_data_dict.get(b"sum_score"),
-                        handicap_score=participant_data_dict.get(b"handicap_score"),
-                        is_group_win=participant_data_dict.get(b"is_group_win"),
-                        is_group_win_handicap=participant_data_dict.get(b"is_group_win_handicap")
-                    )
-
-                    if participant_data.rank is not None and participant_data.handicap_rank is not None:
-                        self.update_participant_rank_in_db(participant.pk, participant_data)
-
-                    # 참가자 포인트 계산 및 저장
-                    participant.calculate_points()
-                    print(f"Participant ID: {participant.pk}, Rank: {participant.rank}, Handicap Rank: {participant.handicap_rank}")
-
-            except Exception as e:
-                logging.error(f"Error updating participant data: {e}")
-
-            # 모든 참가자의 포인트 계산이 끝난 후, 클럽 멤버들의 총 포인트 업데이트
-            try:
-                club = participants[0].event.club  # 첫 번째 참가자가 속한 모임을 가져옴 (모든 참가자가 동일한 클럽에 속해있음)
-                for member in ClubMember.objects.filter(club=club):
-                    member.update_total_points()
-
-                    # 클럽 멤버들의 평균 점수 및 핸디캡 점수 랭킹 업데이트
-                    ClubMember.calculate_avg_rank(club)
-                    ClubMember.calculate_handicap_avg_rank(club)
-
-            except Exception as e:
-                logging.error(f"Error updating club member points or ranks: {e}")
-
-        def transfer_hole_scores_to_db(self, participants):
-            print('transfer_hole_Scores_to_db 실행')
-            # Redis에서 홀 점수를 가져와서 MySQL로 전달
+    def get_event_participants(self, event_id):
+    # 특정 이벤트에 참여한 모든 참가자를 반환
+        return list(Participant.objects.filter(event_id=event_id))
+    
+    def transfer_participant_data_to_db(self, event_id, participants):
+        from clubs.models import ClubMember
+        try:
+            print('transfer_participant_data_to_db 실행')
+            # Redis에서 참가자 데이터를 가져와서 MySQL로 전달
             for participant in participants:
-                score_keys_pattern = f'participant:{participant.pk}:hole:*'
-                score_keys = redis_client.keys(score_keys_pattern)
-                logging.info('score_keys: %s', score_keys)
+                redis_key = f'event:{event_id}:participant:{participant.pk}'
 
-                for key in score_keys:
-                    hole_number = int(key.decode('utf-8').split(':')[-1])
-                    score = int(redis_client.get(key))  # ✅ 동기 호출
-                    self.update_or_create_hole_score_in_db(participant.pk, hole_number, score)
-            print('transfer_hole_Scores_to_db 실행종료')
+                participant_data_dict = self.redis_client.hgetall(redis_key)
+                logging.info('participant_data_dict: %s', participant_data_dict)
 
-        def transfer_event_data_to_db(self, event_id):
-            print('transfer_event_data_to_db 실행')
-            # Redis에서 이벤트 데이터를 가져와서 MySQL로 전달
-            event_key = f'event:{event_id}'
+                # ParticipantUpdateData 객체 생성
+                participant_data = ParticipantUpdateData(
+                    rank=participant_data_dict.get("rank"),
+                    handicap_rank=participant_data_dict.get("handicap_rank"),
+                    sum_score=participant_data_dict.get("sum_score"),
+                    handicap_score=participant_data_dict.get("handicap_score"),
+                    is_group_win=participant_data_dict.get("is_group_win"),
+                    is_group_win_handicap=participant_data_dict.get("is_group_win_handicap")
+                )
 
-            if(not redis_client.exists(event_key)):
-                print(f"event:{event_id} 키가 존재하지 않습니다. 팀 게임이 아닙니다.")
-                return
-            
-            event_data_dict = redis_client.hgetall(event_key)
+                if participant_data.rank is not None and participant_data.handicap_rank is not None:
+                    self.update_participant_rank_in_db(participant.pk, participant_data)
 
-            # EventData 객체 생성
-            event_data = EventData(
-                group_win_team=event_data_dict.get(b"group_win_team"),
-                group_win_team_handicap=event_data_dict.get(b"group_win_team_handicap"),
-                total_win_team=event_data_dict.get(b"total_win_team"),
-                total_win_team_handicap=event_data_dict.get(b"total_win_team_handicap")
-            )
+                # 참가자 포인트 계산 및 저장
+                participant.calculate_points()
+                print(f"Participant ID: {participant.pk}, Rank: {participant.rank}, Handicap Rank: {participant.handicap_rank}")
 
-            self.update_event_data_in_db(event_id, event_data)
-            print('transfer_event_data_to_db 실행종료')
+        except Exception as e:
+            logging.error(f"Error updating participant data: {e}")
 
-        def update_participant_rank_in_db(self, participant_id, participant_data):
-            Participant.objects.filter(id=participant_id).update(**asdict(participant_data))
+        # 모든 참가자의 포인트 계산이 끝난 후, 클럽 멤버들의 총 포인트 업데이트
+        try:
+            club = participants[0].event.club  # 첫 번째 참가자가 속한 모임을 가져옴 (모든 참가자가 동일한 클럽에 속해있음)
+            for member in ClubMember.objects.filter(club=club):
+                member.update_total_points()
+
+                # 클럽 멤버들의 평균 점수 및 핸디캡 점수 랭킹 업데이트
+                ClubMember.calculate_avg_rank(club)
+                ClubMember.calculate_handicap_avg_rank(club)
+
+        except Exception as e:
+            logging.error(f"Error updating club member points or ranks: {e}")
+
+    def transfer_hole_scores_to_db(self, participants):
+        print('transfer_hole_Scores_to_db 실행')
+        # Redis에서 홀 점수를 가져와서 MySQL로 전달
+        for participant in participants:
+            score_keys_pattern = f'participant:{participant.pk}:hole:*'
+            score_keys = self.redis_client.keys(score_keys_pattern)
+            logging.info('score_keys: %s', score_keys)
+
+            for key in score_keys:
+                hole_number = int(key.split(':')[-1])
+                score = int(self.redis_client.get(key))  # ✅ 동기 호출
+                self.update_or_create_hole_score_in_db(participant.pk, hole_number, score)
+        print('transfer_hole_Scores_to_db 실행종료')
+
+    def transfer_event_data_to_db(self, event_id):
+        print('transfer_event_data_to_db 실행')
+        # Redis에서 이벤트 데이터를 가져와서 MySQL로 전달
+        event_key = f'event:{event_id}'
+
+        if(not self.redis_client.exists(event_key)):
+            print(f"event:{event_id} 키가 존재하지 않습니다. 팀 게임이 아닙니다.")
+            return
         
-        def update_event_data_in_db(self, event_id, event_data):
-        # 이벤트 데이터 업데이트
-            Event.objects.filter(id=event_id).update(**asdict(event_data))
+        event_data_dict = self.redis_client.hgetall(event_key)
 
-        def update_or_create_hole_score_in_db(self, participant_id, hole_number, score):
-            return HoleScore.objects.update_or_create(
-                participant_id=participant_id,
-                hole_number=hole_number,
-                defaults={'score': score}
-            )
+        # EventData 객체 생성
+        event_data = EventData(
+            group_win_team=event_data_dict.get("group_win_team"),
+            group_win_team_handicap=event_data_dict.get("group_win_team_handicap"),
+            total_win_team=event_data_dict.get("total_win_team"),
+            total_win_team_handicap=event_data_dict.get("total_win_team_handicap")
+        )
+
+        self.update_event_data_in_db(event_id, event_data)
+        print('transfer_event_data_to_db 실행종료')
+
+    def update_participant_rank_in_db(self, participant_id, participant_data):
+        Participant.objects.filter(id=participant_id).update(**asdict(participant_data))
+    
+    def update_event_data_in_db(self, event_id, event_data):
+    # 이벤트 데이터 업데이트
+        Event.objects.filter(id=event_id).update(**asdict(event_data))
+
+    def update_or_create_hole_score_in_db(self, participant_id, hole_number, score):
+        return HoleScore.objects.update_or_create(
+            participant_id=participant_id,
+            hole_number=hole_number,
+            defaults={'score': score}
+        )


### PR DESCRIPTION
### ✨기능 추가
[feat: redis->mysql 동기화 키 유효기간 자동 갱신](https://github.com/iNESlab/Golbang_BE/commit/63ce0d27205ed700834e43f582726ebcd63e2c53) 

- 일반키 : 웹소켓 접속 참가자 수 관리
- task키 : celery 작업 여부 관리
- 일반키가 삭제되더라도 celery가 작업중인 경우 task키를 통해, celery를 중복 호출하지 않도록 방지.

### 🐛 버그 수정
[hotfix: str -> int 타입 변환](https://github.com/iNESlab/Golbang_BE/commit/7b9a3062845c138c9b87c69e779dfd278be00352) 

- 음수는 .isdigit로 판별 불가능해서 무조건 int를 씌우도록 변경 (대신, try-catch문으로 안전하게 처리)

[hotfix: 음수인 경우에도 int 형변환 되도록 수정](https://github.com/iNESlab/Golbang_BE/commit/e60d171ceca93a767052929863adaea8522c4a31)

[hotfix: 참가자를 못찾는 버그](https://github.com/iNESlab/Golbang_BE/commit/f4e7bf043f7fcc6d458304d181c15c633a9788aa) 

- 전체 랭킹 웹소켓에서는 프론트에서 event_id를 안받음
- 이로 인해, 참가자를 못찾아서, participant_id만으로 키를 찾도록 변경
- 랭킹 조회시, 참가자를 레디스에서 못찾으면 웹소켓 종료시킴(기존 로직에서는 mysql에서 덮어씌워서 sum_score가 리셋됨)
- 에러 응답시, status와 error를 반환하도록 함.
- 정상적인 응답도 status, message, data로 응답해야하는데 프론트 코드 수정까지 이어져야해서 TODO작성