### PR TITLE
Feat: 스코어카드 조회 시 빈 값 Null 반환 및 Redis Null 키 삭제 로직 추가

### DIFF
--- a/participants/models.py
+++ b/participants/models.py
@@ -70,7 +70,7 @@ class Participant(models.Model):
         hole_score_map = {hole.hole_number: hole.score for hole in hole_scores}
         print(f"hole_score_map: {hole_score_map}")
         # 1~18홀 점수를 채우고, 누락된 점수는 0으로 채운다.
-        complete_scorecard = [hole_score_map.get(hole, 0) for hole in range(1, 19)]
+        complete_scorecard = [hole_score_map.get(hole, None) for hole in range(1, 19)]
         print(f"complete_scorecard: {complete_scorecard}")
         return complete_scorecard
 

--- a/participants/models.py
+++ b/participants/models.py
@@ -61,7 +61,7 @@ class Participant(models.Model):
 
     def get_scorecard(self):
         """
-        참가자의 1~18홀 점수를 반환하며, 누락된 점수는 0으로 채운다.
+        참가자의 1~18홀 점수를 반환하며, 누락된 점수는 None으로 채운다.
         """
         # MySQL의 participants_holescore 테이블에서 유저의 스코어카드를 가져오는 로직 (재사용성을 위해 모델에 정의함)
         hole_scores = HoleScore.objects.filter(participant=self).order_by('hole_number')
@@ -69,7 +69,7 @@ class Participant(models.Model):
         # {hole_number: score} 형태로 매핑
         hole_score_map = {hole.hole_number: hole.score for hole in hole_scores}
         print(f"hole_score_map: {hole_score_map}")
-        # 1~18홀 점수를 채우고, 누락된 점수는 0으로 채운다.
+        # 1~18홀 점수를 채우고, 누락된 점수는 None으로 채운다.
         complete_scorecard = [hole_score_map.get(hole, None) for hole in range(1, 19)]
         print(f"complete_scorecard: {complete_scorecard}")
         return complete_scorecard

--- a/participants/stroke/redis_interface.py
+++ b/participants/stroke/redis_interface.py
@@ -133,8 +133,23 @@ class RedisInterface:
         return None
 
     async def update_hole_score_in_redis(self, participant_id, hole_number, score):
-        # Redis에 홀 점수를 업데이트
+        """
+        Redis에 홀 점수를 업데이트하는 함수
+         - score가 None이면 해당 키를 삭제함
+        """
         key = f'participant:{participant_id}:hole:{hole_number}'
+        if score is None:
+            # NULL 전달 시 Redis에서 키 삭제
+            print(f"Score 삭제 → {key}")
+            await sync_to_async(redis_client.delete)(key)
+            # TODO: 아래는 디버깅용 코드. 추후 안정화될 경우 삭제 필요
+            # deleted = await sync_to_async(redis_client.delete)(key)
+            # print(f"[디버그] delete → {key}, deleted={deleted}")
+            # still_exists = await sync_to_async(redis_client.exists)(key)
+            # print(f"[디버그] exists after delete → {still_exists}")  # 0 이면 정상 삭제
+            return
+
+        # 숫자 전달 시 기존 로직
         await sync_to_async(redis_client.set)(key, score)
         await sync_to_async(redis_client.expire)(key, 172800)
 

--- a/participants/stroke/stroke_group_consumers.py
+++ b/participants/stroke/stroke_group_consumers.py
@@ -94,8 +94,8 @@ class GroupParticipantConsumer(AsyncWebsocketConsumer, RedisInterface, MySQLInte
                 await self.send_json(self.handle_404_not_found('Participant', participant_id))
                 return
 
-            if hole_number is None or score is None:
-                await self.send_json({'status': 400, 'error': "Both hole number and score are required."})
+            if hole_number is None:
+                await self.send_json({'status': 400, 'error': "Hole Number is required."})
                 return
 
             await self.update_hole_score_in_redis(participant_id, hole_number, score)


### PR DESCRIPTION
### ✨기능 추가
**[feat: 스코어카드 조회 시 비어있는 값은 0이 아닌 Null로 반환되도록 수정](https://github.com/iNESlab/Golbang_BE/commit/0a5f1ac56af8294ddf9555fe21d31ae825bf3915)** 
- 골프에서는 0도 유효한 값을 가지고 있기에 명확한 정보 전달을 위하여 Null로 수정
- 해당 코드는 출력용으로 다른 계산 로직에 사용되지 않기에 Null로 인한 문제는 없다고 봐도 됨

**[feat: feat: score가 Null일 경우, redis에서 해당 키 값을 삭제하는 로직 추가](https://github.com/iNESlab/Golbang_BE/commit/3971d9a1af460aecf357f57b531784a4b4fa29f2)** 

- 기존: Null을 받아올 수 없도록 설정되어있었음
- [입력하지 않은 값]을 명확히 하기 위해 프론트엔드에서 Null 값을 전달하기로 함.
- 이에 따라 서버에서도 Null을 받아올 수 있도록 하고, 받아오는 경우 redis에서 제거하도록 설정

> [!NOTE]
> - [x] 스코어 Null 반환 테스트 완료
> - [x] 스코어 Null 요청 시, redis 키 삭제 테스트 완료

### 💡 주석 추가/수정
[docs: get_scorecard 함수 내 주석 수정](https://github.com/iNESlab/Golbang_BE/commit/816bf2986cabfc0f541b3c8c9fe822c8c154ae85)

