### PR TITLE
Feat: 그룹별 홀 확인/수정 기능 및 Redis 상태 관리 로직 구현

### DIFF
--- a/participants/stroke/redis_interface.py
+++ b/participants/stroke/redis_interface.py
@@ -6,8 +6,6 @@ participa/stroke/redis_interface.py
 - Redis 데이터베이스와 상호작용하는 클래스
 - 참가자와 이벤트의 데이터를 관리
 '''
-from dataclasses import asdict
-import json
 import logging
 from celery.result import AsyncResult
 
@@ -106,7 +104,9 @@ class RedisInterface:
 
 
     async def save_participant_in_redis(self, participant: Participant):
-        # 참가자 Redis 캐싱 메서드
+        """
+        참가자 Redis 캐싱 메서드
+        """
         key = f'event:{participant.event.pk}:participant:{participant.pk}'
         value = ParticipantRedisData.orm_to_participant_redis(participant=participant).to_redis_dict()
 
@@ -155,23 +155,34 @@ class RedisInterface:
 
 
     async def get_hole_checks(self, event_id: int, group_type: str) -> dict[int, bool]:
-        # Redis에서 hole_checks 해시를 읽어와 hole_number -> bool 매핑 리턴
+        """
+        Redis에서 해당 이벤트·그룹의 hole_checks 해시를 Redis에서 읽어오는 함수
+        Returns:
+            Dict[int, bool]: {홀번호: 확인여부} 매핑 (True=확인, False=미확인)
+        """
         redis_key = f"event:{event_id}:group:{group_type}:hole_checks"
-        logging.info(f"[DEBUG] Redis HGETALL redis_key={redis_key}")
+        # logging.info(f"[DEBUG] Redis HGETALL redis_key={redis_key}")
         raw = await sync_to_async(redis_client.hgetall)(redis_key)
-        logging.info(f"get_hole_checks: {raw}")
+        # logging.info(f"get_hole_checks: {raw}")
 
         return {int(k): bool(int(v)) for k, v in raw.items()}
 
     async def set_hole_check(self, event_id: int, group_type: str, hole_number: int, is_confirmed: bool) -> None:
-        # Redis 해시에 해당 hole_number 필드를 0/1로 설정
+        """
+        해당 이벤트·그룹의 hole_checks 해시에 hole_number 필드를 0/1로 설정하는 함수
+        is_confirmed (bool): 확인 상태 (True 또는 False)
+        0: False, 1: True
+        key: hole_number, value: int(is_confirmed)
+        """
         redis_key = f"event:{event_id}:group:{group_type}:hole_checks"
-        logging.info(f"[DEBUG] Redis HSET redis_key={redis_key}, hole={hole_number}, value={int(is_confirmed)}")
+        # logging.info(f"[DEBUG] Redis HSET redis_key={redis_key}, hole={hole_number}, value={int(is_confirmed)}")
         await sync_to_async(redis_client.hset)(redis_key, hole_number, int(is_confirmed))
 
 
     async def update_participant_sum_and_handicap_score_in_redis(self, participant: ParticipantRedisData):
-        # Redis에 참가자의 총 점수와 핸디캡 점수를 업데이트
+        """
+        Redis에 참가자의 총 점수와 핸디캡 점수를 업데이트
+        """
         keys_pattern = f'participant:{participant.participant_id}:hole:*'
         keys = await sync_to_async(redis_client.keys)(keys_pattern)
 
@@ -188,8 +199,9 @@ class RedisInterface:
         })
 
     async def update_rankings_in_redis(self, event_id):
-        # Redis에 참가자들의 순위를 업데이트
-
+        """
+        Redis에 참가자들의 순위를 업데이트
+        """
         participants = await self.get_event_participants_from_redis(event_id)
 
         # sum_score이 0인 참가자들은 제외
@@ -279,7 +291,9 @@ class RedisInterface:
 
 
     async def get_group_participants_from_redis(self, event_id, group_type_filter=None):
-        # Redis에서 참가자들을 가져옴
+        """
+        Redis에서 참가자들을 가져옴
+        """
 
         event_participants = await self.get_event_participants_from_redis(event_id, group_type_filter)
         if group_type_filter is None:
@@ -368,8 +382,9 @@ class RedisInterface:
         await sync_to_async(redis_client.expire)(event_key, 172800)
 
     async def get_all_hole_scores_from_redis(self, participant_id):
-        # Redis에서 모든 홀 점수를 가져옴
-
+        """
+        Redis에서 모든 홀 점수를 가져옴
+        """
         logging.info('participant_id: %s', participant_id)
         keys_pattern = f'participant:{participant_id}:hole:*'
         keys = await sync_to_async(redis_client.keys)(keys_pattern)
@@ -383,8 +398,9 @@ class RedisInterface:
         return hole_scores
 
     async def get_event_data_from_redis(self, event_id):
-        # Redis에서 이벤트 데이터를 가져옴
-
+        """
+        Redis에서 이벤트 데이터를 가져옴
+        """
         redis_key = f'event:{event_id}'
         event_data_dict = await sync_to_async(redis_client.hgetall)(redis_key)
 

--- a/participants/stroke/stroke_group_consumers.py
+++ b/participants/stroke/stroke_group_consumers.py
@@ -70,57 +70,91 @@ class GroupParticipantConsumer(AsyncWebsocketConsumer, RedisInterface, MySQLInte
             await self.close_with_status(500, str(e))
 
     async def receive(self, text_data=None, bytes_data=None, **kwargs):
+        # 각 사람의 스코어 저장 및 각 참가자 랭킹/총합 저장
+
+        # 로직 실행
         try:
             text_data_json = json.loads(text_data)
+            action = text_data_json.get("action")
+            hole_number = text_data_json.get("hole_number")
+            participant_id = text_data_json.get("participant_id")
 
-            if text_data_json['action'] == 'get':
+            # 수정 요청
+            if action == 'uncheck_hole':
+                await self.set_hole_check(self.event_id, self.group_type, hole_number, False)
                 await self.send_scores()
                 return
 
-            participant_id = text_data_json['participant_id'] # request body로 받는 참가자id
-            hole_number = text_data_json['hole_number']
-            score = text_data_json['score']
-            
-            participant: ParticipantRedisData = await self.get_participant_from_redis(event_id=self.event_id,participant_id=participant_id) # redis에서 참가자 정보 가져오기
-            if(participant is None):
-                # 이미 저장된 참가자가 아닐 경우에만, 조회해서 캐싱
-                participant_mysql: Participant = await self.get_participant(participant_id)
-                if participant_mysql is None:
-                    participant = None
-                else:
-                    participant = await self.save_participant_in_redis(participant_mysql)  # ✅ 캐싱 추가
+            # 확인(계산) 요청
+            elif action == 'confirm_hole':
+                participant = await self.get_participant_from_redis(self.event_id, participant_id)
+                if not participant:
+                    await self.send_json({'status': 404, 'error': f'Participant {participant_id} not found'})
+                    return
 
-            if not participant:
-                await self.send_json(self.handle_404_not_found('Participant', participant_id))
+                await self.update_participant_sum_and_handicap_score_in_redis(participant)
+                await self.update_rankings_in_redis(self.event_id)
+
+                logging.info(f'isTeam? {participant.team_type != Participant.TeamType.NONE}')
+                if participant.team_type != Participant.TeamType.NONE:
+                    # 조별 승리 여부 갱신
+                    await self.update_is_group_win_in_redis(participant)
+                    # 전체 이벤트 승리 팀 갱신
+                    await self.update_event_win_team_in_redis(self.event_id)
+
+                # 확인 상태 저장
+                await self.set_hole_check(self.event_id, self.group_type, hole_number, True)
+
+                # 전체 데이터 전송
+                await self.send_scores()
                 return
 
-            if hole_number is None:
-                await self.send_json({'status': 400, 'error': "Hole Number is required."})
+            # 전체 스코어+상태 조회 요청
+            elif action == 'get':
+                await self.send_scores()
                 return
 
-            await self.update_hole_score_in_redis(participant_id, hole_number, score)
-            await self.update_participant_sum_and_handicap_score_in_redis(participant)
-            await self.update_rankings_in_redis(self.event_id)
+            # 스코어 입력
+            elif action == 'post': # TODO: input_score or update_score
+                participant_id = text_data_json['participant_id']  # request body로 받는 참가자id
+                hole_number = text_data_json['hole_number']
+                score = text_data_json['score']
 
-            logging.info(f'isTeam? {participant.team_type != Participant.TeamType.NONE}')
-            if participant.team_type != Participant.TeamType.NONE:
-                logging.info(f'참가자는 팀에 있습니다.')
-                # 조별 승리 여부 갱신
-                await self.update_is_group_win_in_redis(participant)
-                # 전체 이벤트 승리 팀 갱신
-                await self.update_event_win_team_in_redis(participant.event_id)
+                participant: ParticipantRedisData = await self.get_participant_from_redis(event_id=self.event_id,
+                                                                                          participant_id=participant_id)  # redis에서 참가자 정보 가져오기
+                if (participant is None):
+                    # 이미 저장된 참가자가 아닐 경우에만, 조회해서 캐싱
+                    participant_mysql: Participant = await self.get_participant(participant_id)
+                    if participant_mysql is None:
+                        participant = None
+                    else:
+                        participant = await self.save_participant_in_redis(participant_mysql)  # ✅ 캐싱 추가
 
-            participant = await self.get_participant_from_redis(event_id=self.event_id,participant_id=participant_id) # redis에서 갱신된 참가자 정보 가져오기
-            response_data_dict = asdict(participant)
-            response_data_dict["hole_number"] = hole_number
-            response_data_dict["score"] = score
+                if not participant:
+                    await self.send_json(self.handle_404_not_found('Participant', participant_id))
+                    return
 
-            await self.channel_layer.group_send(self.group_name, {
-                'type': 'input_score',
-                **response_data_dict  # Send all response data
-            })
+                if hole_number is None:
+                    await self.send_json({'status': 400, 'error': "Hole Number is required."})
+                    return
 
-            await self.save_celery_event_from_redis_to_mysql(self.event_id, is_count_incr=False) # count 증가 없이, 자동 저장 시간 연장
+                await self.update_hole_score_in_redis(participant_id, hole_number, score)
+
+                participant = await self.get_participant_from_redis(event_id=self.event_id,
+                                                                    participant_id=participant_id)  # redis에서 갱신된 참가자 정보 가져오기
+                response_data_dict = asdict(participant)
+                response_data_dict["hole_number"] = hole_number
+                response_data_dict["score"] = score
+
+                await self.channel_layer.group_send(self.group_name, {
+                    'type': 'input_score',
+                    **response_data_dict  # Send all response data
+                })
+
+                await self.save_celery_event_from_redis_to_mysql(self.event_id,
+                                                                 is_count_incr=False)  # count 증가 없이, 자동 저장 시간 연장
+
+                return
 
         except ValueError as e:
             await self.close_with_status(500, str(e))
@@ -148,7 +182,7 @@ class GroupParticipantConsumer(AsyncWebsocketConsumer, RedisInterface, MySQLInte
     async def send_scores(self):
         try:
             # 그룹에 속한 모든 참가자를 한 번의 쿼리로 가져옴
-            participants = await self.get_group_participants_from_redis(self.event_id,self.group_type)
+            participants = await self.get_group_participants_from_redis(self.event_id, self.group_type)
             logging.info(f'participants: {participants}')
             # 각 참가자의 홀 스코어를 비동기로 병렬 처리
             group_scores = await asyncio.gather(*[
@@ -156,10 +190,15 @@ class GroupParticipantConsumer(AsyncWebsocketConsumer, RedisInterface, MySQLInte
             ])
             logging.info(f'group_scores: {group_scores}')
 
-            await self.send_json(group_scores)
+            hole_checks = await self.get_hole_checks(self.event_id, self.group_type)
+            logging.info(f"hole_checks: {hole_checks}")
+
+            await self.send_json({
+                'scores': group_scores,
+                'hole_checks': hole_checks,
+            })
         except Exception as e:
             await self.send_with_status(500, f'스코어 기록을 가져오는 데 실패했습니다, {e}')
-
 
     async def process_participant(self, participant):
         participant_id = participant.participant_id
@@ -172,7 +211,7 @@ class GroupParticipantConsumer(AsyncWebsocketConsumer, RedisInterface, MySQLInte
             'team_type': participant.team_type,
             'is_group_win': participant.is_group_win,
             'is_group_win_handicap': participant.is_group_win_handicap,
-            'sum_score':participant.sum_score,
+            'sum_score': participant.sum_score,
             'handicap_score': participant.handicap_score,
             'scores': hole_scores,
         }


### PR DESCRIPTION
### ✨기능 추가
[feat: 홀 체크용 redis 메서드 (get_hole_checks, set_hole_check) 메서드 추가](https://github.com/iNESlab/Golbang_BE/commit/cc82ed59a24cb39af4bbc7ecceeca977a34b5239) 

- 확인/수정 버튼을 누를 경우 확인 상태를 저장하는 것이 필요하다.
- 이를 위해 redis에 'event:{event_id}:group:{group_type}:hole_checks'패턴으로 값을 저장한다.
- get과 set을 두어 요청 들어왔을 시에는 set으로 저장하고, send_scores로 데이터를 보내줄 때는 get으로 가져온다.


[feat: 그룹별 홀 확인/수정 기능 및 상태 관리 로직 구현](https://github.com/iNESlab/Golbang_BE/commit/be454eaed318a865e6e36cafe98a0c6939926960) 

- 확인/수정 요청에 따라 다른 로직을 수행할 필요가 있었습니다.
- 수정 요청: uncheck_hole, 확인 요창: confirm_hole, 입력: post로 분기처리했습니다.
- 확인/수정 부분에서 홀 상태 여부를 관리합니다.


### ♻ 코드 리팩토링
[refactor: receive() JSON 파싱 오류(400)와 로직 오류(500) 분리 처리](https://github.com/iNESlab/Golbang_BE/commit/07af6f42baee6035549abbec3f139db925a189d8) 

- 에러 디버깅 시 도움이 되기 위해 에러 핸들링 코드를 추가했습니다.
- JSON 파싱 오류와 로직 오류, 그리고 잘못된 action 값에 대한 에러 핸들링을 추가했습니다


### 💡 주석 추가/수정
[docs: RedisInterface 클래스 내 함수 설명 추가](https://github.com/iNESlab/Golbang_BE/commit/6f4423ac56f992cf514ee96ff3cf3d609815e611)

[docs: GroupParticipantConsumer 클래스 내 receive 함수와 send_scores 함수에 설명 추가](https://github.com/iNESlab/Golbang_BE/commit/dec0b4c37e8f0bfcdb01de93eba4bdf0dc4fbbbb)


### 테스트
