### PR TITLE
Fix: Celery동기화 시간 조정 & Celery TypeError 버그픽스

### DIFF
--- a/participants/tasks.py
+++ b/participants/tasks.py
@@ -49,7 +49,7 @@ def save_event_periodically_task(event_id: int):
             redis_client.delete(task_key)
             break
 
-        time.sleep(30) #TODO: 테스트 후에 10분 이상조정해주세요
+        time.sleep(900) # 15분 간격으로 동기화
 
 
 class MigrationMySQLInterface:


### PR DESCRIPTION
## #️⃣연관된 이슈
> #166 


## 📝작업 내용
### ✨기능 변경
[fix: 30초 간격이 아닌 15분 간격으로 동기화되도록 수정](https://github.com/iNESlab/Golbang_BE/commit/50b03ad8f37f151b4be4a448ff61be8513f9bdc9)
- 인수인계 이슈에 적힌 내용대로 **30초에서 15분 간격**으로 동기화하도록 수정했습니다.

### 🐛 버그 수정
[bugfix: calculate_club_ranks_and_points 함수 인자 optional 처리 & 인자가 없는 경우 전체 모임을 순회하도록 구성](https://github.com/iNESlab/Golbang_BE/pull/173/commits/c79221c4bf15a6096705c842e443969c448c2417)

- **문제**
 Celery Beat가 `calculate_club_ranks_and_points` 를 인자 없이 호출하면서 `TypeError: missing 1 required positional argument: 'club_id'` 에러가 발생함.
 - **원인**
   - 해당 태스크 함수가 `club_id` 를 필수 인자로 선언되어 있어, 기본값 없이 호출 시 인자 검증 단계에서 실패함.
   (`def calculate_club_ranks_and_points(club_id):`)
   - `settings.py` 의 Celery Beat 스케줄 설정에서 args 없이 해당 태스크를 호출하도록 되어 있었음. 인자가 있는 경우 'args'를 추가해야 한다고 함. 하지만 매일 자정에 한번에 모든 모임을 업데이트하는 것이므로 함수를 수정해야 했음.
    ```python
    CELERY_BEAT_SCHEDULE = {
            'update-club-rankings-every-day': {
                'task': 'clubs.tasks.calculate_club_ranks_and_points',
                'schedule': crontab(minute=0, hour=0),  # 매일 자정에 실행
            },
        }
    ```
 - **해결**
   - `tasks.py` 에서 함수 정의를 `def calculate_club_ranks_and_points(club_id=None):` 처럼 기본값을 설정
   - `calculate_club_ranks_and_points` 내에서 인자가 있는 경우와 없는 경우를 분기 처리하도록 로직 추가

> [!IMPORTANT]
> 테스트 필요