### PR TITLE
Fix: confirm_hole 시 조원 전체 점수 및 랭킹 반영 버그 수정 & sum_score 0인 경우에도 랭킹에 나오도록 개선

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,7 @@ services:     # 컨테이너 지정
     image: redis:latest
     restart: always
     ports:
-      - "6379:6379"
+      - "6380:6379"
     environment:
       - REDIS_PASSWORD=${MYSQL_DB_PASSWORD}
     command: redis-server --requirepass ${MYSQL_DB_PASSWORD}

--- a/participants/stroke/redis_interface.py
+++ b/participants/stroke/redis_interface.py
@@ -204,11 +204,8 @@ class RedisInterface:
         """
         participants = await self.get_event_participants_from_redis(event_id)
 
-        # sum_score이 0인 참가자들은 제외
-        participants = [p for p in participants if p.sum_score != 0]
-
-        sorted_by_sum_score = sorted(participants, key=lambda p: p.sum_score)
-        sorted_by_handicap_score = sorted(participants, key=lambda p: p.handicap_score)
+        sorted_by_sum_score = sorted(participants, key=lambda p: p.sum_score or 0)  # 스코어가 None일 경우 0으로 대체
+        sorted_by_handicap_score = sorted(participants, key=lambda p: p.handicap_score or 0)
 
         self.assign_ranks(sorted_by_sum_score, 'sum_rank')
         self.assign_ranks(sorted_by_handicap_score, 'handicap_rank')

--- a/participants/stroke/stroke_event_consumers.py
+++ b/participants/stroke/stroke_event_consumers.py
@@ -133,8 +133,8 @@ class EventParticipantConsumer(AsyncWebsocketConsumer, MySQLInterface, RedisInte
 
         rank_data = await self.get_event_rank_from_redis(participant.event_id, participant)
 
-        # 아직 점수입력이 안된 참가자는 제외
-        if rank_data.sum_score == 0:
+        # 아직 점수 입력을 하지 않은 참가자 정보 제외
+        if rank_data.last_hole_number == 0:
             return None
 
         return {


### PR DESCRIPTION
## 🐛 버그 수정
### [fix: confirm_hole 액션 시 모든 조원 sum_score·handicap_score 및 랭킹 반영](https://github.com/iNESlab/Golbang_BE/commit/cbef9f44e68f9fe600ce43c668884bf67eed5a75) 
  

- **문제점**: `confirm_hole` 호출 시 요청자만 `sum_score·handicap_score`가 갱신되고, 나머지 조원은 반영되지 않음. 
  <img width="200" alt="스크린샷 2025-05-06 오전 12 04 41" src="https://github.com/user-attachments/assets/8be6f7a3-80c6-461f-a0de-3c347559a30c" /> <img width="200" alt="스크린샷 2025-05-06 오전 12 04 46" src="https://github.com/user-attachments/assets/4a7a6531-1a6d-40fc-a148-20096e753ef3" />
  → P2, P3, P4도 입력했지만 랭킹에는 반영되지 않음
- **원인**: `update_participant_sum_and_handicap_score_in_redis` 함수가 요청자에 대해서만 호출되도록 변경되어 그룹 전체에 대한 점수 갱신이 누락됨
 (로직 분리하면서 발생한 mistake)
- **해결**:
  1. `get_group_participants_from_redis`로 조원 전체 목록을 조회
  2. `asyncio.gather`로 모든 조원에 대해 `sum_score·handicap_score` 및 `is_group_win`을 일괄 갱신

### [fix: sum_score가 0인 경우 랭킹 정보에 포함되지 않는 문제 해결](https://github.com/iNESlab/Golbang_BE/commit/bef69130d0989907d304af787950fde9fa558cbe) 
- **문제**: `sum_score`가 0인 경우에도 유효한 점수임에도 불구하고 랭킹에서 제외됨
  <img width="200" alt="스크린샷 2025-05-06 오전 12 04 41" src="https://github.com/user-attachments/assets/a4e7e9c9-687d-4c2e-aa19-612105f78e78" /> <img width="200" alt="스크린샷 2025-05-06 오전 12 04 46" src="https://github.com/user-attachments/assets/10a906c5-66fb-492d-bb31-3ed74fa0e059" />
  → P1, P2의 sum_score가 0인데 랭킹에 표시되지 않음
- **원인**: s`um_score == 0`인 참가자를 필터링하는 코드 존재
- **해결**:
  1. `sum_score == 0`을 제외하지 않도록 필터링 코드 제거
  2. `None`인 경우를 0으로 대체해 `TypeError` 방지
  3. 점수 입력 여부 판단 기준을 sum_score → last_hole_number로 변경 (→ sum_score가 0이어도 랭킹 반영을 위한 목적)
  (이제는 sum_score가 0이어도 랭킹에 나옴)
  <img width="200" alt="스크린샷 2025-05-06 오전 12 13 58" src="https://github.com/user-attachments/assets/66480c61-a7d6-403a-96c8-2b43196e7972" />


## 🔧 구성 파일 변경
### [chore: local docker compose redis 포트 주소 변경](https://github.com/iNESlab/Golbang_BE/commit/32a014d6e63a79c300515863e84e12b71cf4866f) 
- 민정 로컬에서 6379가 사용중이라 6380으로 변경 

## 📌테스트 여부
- [x] `confirm_hole` 클릭 시 조원 전체의 `sum_score/handicap_score` 반영 확인
- [x] `sum_score`가 0인 경우에도 랭킹 정보에 포함되는지 확인

