### PR TITLE
hotfix: 임시비밀번호 발급 후 원하는 비밀번호로 변경하기 위한 대안으로 관리자가 직접 변경할 수 있는 코드 추가 (추후삭제예정)

### DIFF
--- a/accounts/admin.py
+++ b/accounts/admin.py
@@ -7,6 +7,7 @@ accounts/admin.py
 from django.contrib import admin
 from django.contrib.auth.models import Group
 from django.contrib.auth.admin import UserAdmin as BaseUserAdmin
+from django.contrib.auth.forms import AdminPasswordChangeForm  # TODO: 비밀번호 변경 후 다시 제거해야 함
 
 from accounts.forms import UserChangeForm, UserCreationFirstStepForm
 from accounts.models import User
@@ -19,7 +20,8 @@ from accounts.models import User
 class CustomUserAdmin(BaseUserAdmin):
     form = UserChangeForm
     add_form = UserCreationFirstStepForm
-
+    # 관리자 화면에서 다른 유저 비밀번호 변경 폼을 사용하도록 설정
+    change_password_form = AdminPasswordChangeForm # TODO: 비밀번호 변경 후 다시 제거해야 함
 
     list_display        = ('user_id', 'email', 'name', 'phone_number', 'handicap', 'date_of_birth', 'is_admin')
     list_filter         = ('is_admin',)

--- a/accounts/forms.py
+++ b/accounts/forms.py
@@ -53,8 +53,7 @@ class UserCreationSecondStepForm(forms.ModelForm):
 '''
 class UserChangeForm(forms.ModelForm):
     # password는 읽기 전용. (사용자 정보 수정시 비밀번호 변경 X)
-    password = ReadOnlyPasswordHashField()
-
+    password = ReadOnlyPasswordHashField(label="비밀번호")
     class Meta:
         model   = User
         fields  = ['user_id', 'email', 'password', 'name', 'phone_number', 'handicap', 'date_of_birth', 'address', 'student_id',


### PR DESCRIPTION
### ✨ [Hotfix] 기능 추가
- 비밀번호를 임시 발급 받은 후 지문인식 로그인이 되지 않는 문제가 발생했습니다.
- 사용자가 최대한 빨리 로그인이 되도록 해야 하기 때문에 시간이 오래 걸리는 지문인식 디버깅과 비밀번호 변경 탭 추가 대신에 관리자가 일단 직접 바꿔주기로 결정했습니다.
- 이에 따라 관리자 페이지에서 사용자의 비밀번호를 바꿀 수 있도록 설정했습니다.

> [!IMPORTANT]
> **오늘 비밀번호를 변경해드린 후 바로 다시 없앨 예정입니다.**

## 📌추후 삭제 예정에 있습니다.
