### PR TITLE
feat: 이벤트 참가자 일괄 관리 API 추가 · 권한 검사 로직 개선 · 로그인 검증 세분화

### DIFF
--- a/auth/api.py
+++ b/auth/api.py
@@ -18,6 +18,8 @@ from django.views.decorators.csrf import ensure_csrf_cookie, csrf_exempt  # CSRF
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework_simplejwt.tokens import RefreshToken # RefreshToken
 
+import logging
+
 User = get_user_model() # 사용자 모델을 변수에 할당
 
 '''
@@ -37,29 +39,48 @@ class LoginApi(APIView):
         password        = request.data.get('password')
         fcm_token       = request.data.get('fcm_token')
 
-        # 이메일이나 비밀번호가 없을 경우 -> 400 bad request 응답
-        if not userid_or_email or not password:
+        # 1. 이메일이나 비밀번호가 없을 경우 -> 400 bad request 응답
+        if not userid_or_email and not password:
+            logging.error(f"[LOGIN ERROR]Username or email and password are required")
             return Response({
                 "status" : status.HTTP_400_BAD_REQUEST,
-                "message": "username/email and password required"
+                "message": "username/email 과 password가 필요합니다"
             }, status=status.HTTP_400_BAD_REQUEST)
-
-        # 사용자 인증
-        user = authenticate(username=userid_or_email, password=password)
-
-        ## 사용자가 없는 경우 -> 404 not found 응답
-        if user is None:
+        
+        elif not userid_or_email:
+            logging.error(f"[LOGIN ERROR]Username or email is required")
+            return Response({
+                "status" : status.HTTP_400_BAD_REQUEST,
+                "message": "username/email이 필요합니다"
+            }, status=status.HTTP_400_BAD_REQUEST)
+        
+        elif not password:
+            logging.error(f"[LOGIN ERROR]Password is required")
+            return Response({
+                "status" : status.HTTP_400_BAD_REQUEST,
+                "message": "password가 필요합니다"
+            }, status=status.HTTP_400_BAD_REQUEST)
+            
+        # 2. 이메일 (또는 username)으로 사용자 검색 
+        # 사용자가 없는 경우 -> 404 not found 응답
+        try:
+            user = User.objects.get(email=userid_or_email)
+        except User.DoesNotExist:
+            logging.error(f"[LOGIN ERROR]User does not exist: {userid_or_email}")
             return Response({
                 "status" : status.HTTP_404_NOT_FOUND,
-                "message": "User does not exist(Not Found)"
+                "message": "Email 또는 Username을 찾을 수 없습니다."
             }, status=status.HTTP_404_NOT_FOUND)
 
-        ## 비밀번호가 일치하지 않는 경우 -> 400 bad request응답
+        # 3. 비밀번호 검증 (비밀번호가 일치하지 않는 경우 -> 400 bad request)
         if not user.check_password(password):
+            logging.error(f"[LOGIN ERROR]Password does not match: {userid_or_email}")
             return Response({
                 "status" : status.HTTP_400_BAD_REQUEST,
-                "message": "Passwords do not match"
+                "message": "비밀번호가 일치하지 않습니다."
             }, status=status.HTTP_400_BAD_REQUEST)
+
+        user = authenticate(username=userid_or_email, password=password)
 
         # FCM 토큰이 비어 있거나 다르면 업데이트
         if fcm_token:


### PR DESCRIPTION
## 📝작업 내용
> 정리한 노션이 있다면 추가해주세요.
- **API 명세서**

### ✨기능 추가
**[feat(participants/views): 이벤트 참가자 일괄 관리 API 추가](https://github.com/iNESlab/Golbang_BE/commit/0400b842a8c18a27596b00b6ccb82872ae5cbe92)**

- 이벤트 수정이 아니라 상세 페이지에서도 바로 이벤트의 참가자를 추가/삭제할 수 있는 기능이 필요했음.
- 이에 참가자만 추가/삭제, 조 변경할 수 있는 API만 따로 추가함
- API 명세에 추가 완료 & Postman 테스트 완료
  - POST `/events/{event_id}/add-participants/` : 이벤트에 참가자 여러 명을 한 번에 추가
  - POST `/events/{event_id}/remove-participants/` : 이벤트에서 참가자 여러 명을 한 번에 제거
  - PATCH `/events/{event_id}/update-participants/` : 참가자의 `group_type`(조) 정보를 일괄 수정

<img width="830" alt="스크린샷 2025-05-11 오후 9 56 18" src="https://github.com/user-attachments/assets/3c4a283c-cb9f-46c4-8d21-3e4fe11267d8" />

### 🐛 버그 수정
**[feat: IsClubAdmin 권한 검사 로직 개선](https://github.com/iNESlab/Golbang_BE/commit/bc0c9c5db70edbfec8c73e279e98cc59c76a6f5e)**

- **문제**: EventViewSet의 add-participants 등 커스텀 액션 호출 시 `has_object_permission`에 넘어오는 `obj`가 `Event` 인스턴스로, 기존에 `club=obj`로 처리하던 `ClubMember` 쿼리에서 “Must be Club instance” 오류 발생
- **원인**:
`IsClubAdmin` 권한 클래스가 `obj`를 항상 `Club`으로만 가정하여, `Event`가 넘어올 때도 그대로 `club=obj`로 쿼리하도록 구현되어 있었음
- **해결**:
  `has_object_permission` 내부에서
  - `obj`가 `Event`면 `obj.club`을 꺼내고,
  - 그렇지 않으면 `obj`를 그대로 `Club`으로 간주하도록 분기 처리 추가
  이를 통해 Club과 Event 양쪽 모두에서 관리자 권한 검사가 올바르게 작동하도록 수정


### 💡 주석 추가/수정
**[refact: 로그인 처리 로직에서 이메일, 비밀번호 검증 부분을 세분화하고 로그 출력하는 코드 추가](https://github.com/iNESlab/Golbang_BE/commit/04970926e6411c99842c44a48f502d252aed5189), [fix: 로그인 시 사용자 정보(email/username)을 불러오지 못하는 문제를 해결하기 위해 User 모델을 불러오는…](https://github.com/iNESlab/Golbang_BE/commit/e27076719ae69ca5af07b8546b666029fb9d8abf)**
- **문제**: 로그인이 실패할 경우, 이메일인지 비밀번호인지 원인을 알 수 없는 문제 발생. 
- **해결**: 이메일과 비밀번호를 각각 따로 검증하고 처리하도록 로직 분리 & 로그 출력 추가
- Postman 테스트 완료
- 참고: 비밀번호와 사용자 이메일/아이디에 대한 Response는 원래 있었지만 프론트엔드에서 바로 띄워줄 수 있도록 영어에서 한국어로 바꿨습니다. 
유저 이메일/아이디가 존재하지 않는 경우 
<img width="1254" alt="스크린샷 2025-05-11 오후 10 00 26" src="https://github.com/user-attachments/assets/15281885-a670-4cd4-ae2b-c204369810e5" />
<img width="520" alt="스크린샷 2025-05-11 오후 10 01 57" src="https://github.com/user-attachments/assets/50d795c1-e617-48f4-a6c9-d810ebe2fd9d" />

> 비밀번호가 일치하지 않는 경우
<img width="1264" alt="스크린샷 2025-05-11 오후 10 00 42" src="https://github.com/user-attachments/assets/7b318fc1-83df-4b97-a4c8-f1a6169c28f0" />
<img width="679" alt="스크린샷 2025-05-11 오후 10 01 44" src="https://github.com/user-attachments/assets/1cced233-360a-441c-a3a8-8de21272104f" />


## 📌보완해야 할 점 (선택)
- 제가 예전에 `celery beat`로 했던 건 랭킹 말고 모임별 랭킹, 즉 이벤트 말고 모임 내에서 자기 자신의 랭킹을 계산하는 로직이었습니다. 따라서 게임 종료 시에 Null이면 계산하지 않는 로직을 위해 함수를 따로 추가해야했습니다. 현재는 redis에서 mysql로 동기화하는 로직이 전부이기에 매번 동기화를 시키는 코드에 Null인 홀 점수를 가진 사용자를 제외하여 랭킹 재계산 로직을 추가하였습니다. 하지만 이것보다는 이벤트가 끝날 때 한 번만 동작하는 게 좋을 것 같아서 좀 더 손 보는 중입니다. 그래서 이번 PR에는 제외하고 올렸습니다.

## 💬 리뷰 요구사항(선택)
### API의 request body & response body에 대해 피드백주시길 바랍니다!!!!!