### PR TITLE
hotfix: mysql에서 불러올 때, sum_score = 0 초기화

### DIFF
--- a/participants/views/participants_view.py
+++ b/participants/views/participants_view.py
@@ -71,6 +71,10 @@ class ParticipantViewSet(viewsets.ModelViewSet, RedisInterface, MySQLInterface):
         try:
             score = request.data.get("score")
             hole_number = request.data.get("hole_number")
+
+            if not 1 <= hole_number <= 18:
+                return handle_400_bad_request("유효한 hole_number (1~18)를 입력해주세요.")
+
             event_id = request.data.get("event_id")
             participant_id = request.data.get("participant_id")
             if event_id is None:
@@ -87,6 +91,9 @@ class ParticipantViewSet(viewsets.ModelViewSet, RedisInterface, MySQLInterface):
                 if participant_mysql is None:
                     logging.info(f"participant_mysql: {participant_mysql}")
                     return handle_404_not_found('participant', participant_id)
+                
+                # 참가자 정보를 읽을 때, sum_score를 초기화
+                participant_mysql.sum_score = 0
 
                 participant_redis = self.save_sync_participant_in_redis(participant_mysql)
                 logging.info(f"participant_redis saved: {participant_redis}, type: {type(participant_redis)}")


### PR DESCRIPTION
## GPT 질문
자 한번 생각해보자
1. redis -> mysql 동기화는 15분마다 일어나
2. redis에 캐싱되면 mysql에서 참가자 정보를 읽지 않아
3. 하지만, 캐싱이 안돼있으면 Mysql에서 참가자(랭킹, 스코어 등)의 정보를 읽어서 레디스에 캐싱해
4. 여기서 mysql에 동기화해서 점수를 저장했다가 redis에서 점수를 지워버렸어.
5. **근데, 점수는 삭제된건 동기화가 안돼. 어떤게 삭제됐는지 모르기 때문.**
6. 그래도 점수가 일부라도 있으면 참가자 정보는 redis에 살아 있어서 mysql에서 다시 읽어오진 않아 정보 불일치는 신경 안써도 됨.
7. 단, 모든 점수를 삭제하면 참가자 정보를 레디스에서 삭제하기 때문에, 이때는 다시 mysql에서 캐싱하게 되는데
이 때 sum_score나 hole_score값이 달라지게 됨.
8. 이걸 해결하려면,  hole_score를 mysql에서 불러와 레디스에 캐싱할게 아니라 그냥 삭제해버리고, sum_score도 0으로 초기화하는게 맞나?

hole_score를 mysql에서 읽어오는 코드는 필요가 없는건가 이렇게 되면?

## GPT 답변
✅ 요점: MySQL이 "진실"이 아니다
Redis가 일종의 "Single Source of Truth"가 되어버린 구조예요.

삭제는 Redis에서만 발생하고,

MySQL은 삭제된 정보를 모름 (동기화 주기는 15분)

그런데 Redis 캐시가 날아간 후 다시 MySQL에서 복구하면?
👉 이미 삭제된 데이터를 부활시키는 셈

❌ MySQL에서 HoleScore를 불러와 Redis에 캐싱하는 로직은 제거하는 것이 맞습니다.
❌ sum_score가 MySQL에 있어도 그것도 신뢰하면 안 됩니다.